### PR TITLE
Add frontmatter to skills missing YAML metadata

### DIFF
--- a/obsidian-vault/SKILL.md
+++ b/obsidian-vault/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: obsidian-vault
+description: Navigate and manage an Obsidian vault with wikilinks, index notes, and proper naming conventions. Use when working with Obsidian notes, searching the vault, creating new notes, or finding related content.
+---
+
 # Obsidian Vault
 
 ## Vault location

--- a/prd-to-issues/SKILL.md
+++ b/prd-to-issues/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: prd-to-issues
+description: Break a PRD into independently-grabbable GitHub issues using vertical slices (tracer bullets). Use when user wants to convert a PRD into implementation issues, create GitHub issues from a spec, or plan work as vertical slices.
+---
+
 # PRD to Issues
 
 Break a PRD into independently-grabbable GitHub issues using vertical slices (tracer bullets).

--- a/scaffold-exercises/SKILL.md
+++ b/scaffold-exercises/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: scaffold-exercises
+description: Create exercise directory structures that pass lint validation with proper naming conventions and required files. Use when user wants to scaffold exercises, create lesson directories, or set up exercise problem/solution folders.
+---
+
 # Scaffold Exercises
 
 Create exercise directory structures that pass `pnpm ai-hero-cli internal lint`.

--- a/write-a-prd/SKILL.md
+++ b/write-a-prd/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: write-a-prd
+description: Create comprehensive Product Requirements Documents (PRDs) through structured user interviews, codebase exploration, and detailed planning. Use when user wants to write a PRD, create a product spec, or plan a feature implementation.
+---
+
 This skill will be invoked when the user wants to create a PRD. You should go through the steps below. You may skip steps if you don't consider them necessary.
 
 1. Ask the user for a long, detailed description of the problem they want to solve and any potential ideas for solutions.


### PR DESCRIPTION
Adds YAML frontmatter with name and description to 4 skills that were missing it.

So running `npx skills add mattpocock/skills` would show all the skills