### PR TITLE
feat: improve skill scores across 11 skills

### DIFF
--- a/design-an-interface/SKILL.md
+++ b/design-an-interface/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: design-an-interface
-description: Generate multiple radically different interface designs for a module using parallel sub-agents. Use when user wants to design an API, explore interface options, compare module shapes, or mentions "design it twice".
+description: Generate multiple radically different interface designs for a module using parallel sub-agents, compare trade-offs, and synthesize the best approach. Use when user wants to design an API, explore interface options, compare module shapes, or mentions "design it twice".
 ---
 
 # Design an Interface

--- a/edit-article/SKILL.md
+++ b/edit-article/SKILL.md
@@ -1,14 +1,20 @@
 ---
 name: edit-article
-description: The user will invoke this skill to help them edit an article.
+description: Edit and restructure articles by analyzing information dependencies, dividing into sections, and rewriting for clarity with concise paragraphs (max 240 chars). Use when user wants to edit an article, improve article structure, rewrite sections for clarity, or restructure content flow.
 ---
 
-1. First, divide the article into sections based on its headings. Think about the main points you want to make during those sections.
+# Edit Article
 
-Consider that information is a directed acyclic graph, and that pieces of information can depend on other pieces of information. Make sure that the order of the sections and their contents respects these dependencies.
+## Workflow
 
-Confirm the sections with the user.
+### 1. Analyze and section the article
 
-2. For each section:
+Divide the article into sections based on its headings. For each section, identify the main points to communicate.
 
-2a. Rewrite the section to improve clarity, coherence, and flow. Use maximum 240 characters per paragraph.
+Information forms a directed acyclic graph — pieces of information depend on other pieces. Ensure the order of sections and their contents respects these dependencies.
+
+Present the proposed sections to the user for confirmation before proceeding.
+
+### 2. Rewrite each section
+
+For each confirmed section, rewrite to improve clarity, coherence, and flow. Keep paragraphs to a maximum of 240 characters.

--- a/git-guardrails-claude-code/SKILL.md
+++ b/git-guardrails-claude-code/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: git-guardrails-claude-code
+name: git-guardrails
 description: Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, branch -D, etc.) before they execute. Use when user wants to prevent destructive git operations, add git safety hooks, or block git push/reset in Claude Code.
 ---
 

--- a/grill-me/SKILL.md
+++ b/grill-me/SKILL.md
@@ -1,1 +1,31 @@
-Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+---
+name: grill-me
+description: Conduct a relentless interview about every aspect of a plan, walking down each branch of the design tree and resolving dependencies between decisions one-by-one until reaching shared understanding. Use when user wants to stress-test a plan, be grilled on a design, validate assumptions, or needs a thorough design review.
+---
+
+# Grill Me
+
+Interview the user relentlessly about every aspect of their plan until reaching a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
+
+## Workflow
+
+### 1. Understand the plan
+
+Ask the user to present their plan. Identify all major decision points and assumptions.
+
+### 2. Probe each branch
+
+For each decision point, drill down:
+
+- What alternatives were considered?
+- What happens if this assumption is wrong?
+- What are the dependencies on other decisions?
+- What are the failure modes?
+
+### 3. Resolve dependencies
+
+When two decisions depend on each other, resolve the dependency explicitly. Confirm the resolution with the user before moving on.
+
+### 4. Confirm shared understanding
+
+Summarize the final state of the plan, listing all resolved decisions and remaining open questions. Get explicit confirmation from the user.

--- a/obsidian-vault/SKILL.md
+++ b/obsidian-vault/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: obsidian-vault
+description: Manage an Obsidian knowledge vault with flat structure, Title Case naming, wikilinks, and index notes. Searches, creates, and links notes in the vault. Use when user wants to create, search, or organize notes in their Obsidian vault, or mentions Obsidian, wikilinks, or knowledge management.
+---
+
 # Obsidian Vault
 
 ## Vault location

--- a/prd-to-issues/SKILL.md
+++ b/prd-to-issues/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: prd-to-issues
+description: Break a PRD into independently-grabbable GitHub issues using vertical slices (tracer bullets). Creates issues with dependency ordering, HITL/AFK classification, and acceptance criteria. Use when user wants to convert a PRD into issues, break down a feature into tasks, or create GitHub issues from a product requirements document.
+---
+
 # PRD to Issues
 
 Break a PRD into independently-grabbable GitHub issues using vertical slices (tracer bullets).

--- a/request-refactor-plan/SKILL.md
+++ b/request-refactor-plan/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: request-refactor-plan
-description: Use this skill when user wants to create a refactor plan.
+description: Create detailed refactor plans through problem exploration, codebase verification, option analysis, and user interviews. Breaks implementation into tiny commits and produces a GitHub issue with the plan. Use when user wants to plan a refactor, create a refactoring strategy, restructure code, reduce technical debt, or needs a step-by-step refactoring breakdown.
 ---
 
-This skill will be invoked when the user wants to create a refactor request. You should go through the steps below. You may skip steps if you don't consider them necessary.
+Guides the user through creating a refactor plan via the steps below. Steps may be skipped if not necessary.
 
 1. Ask the user for a long, detailed description of the problem they want to solve and any potential ideas for solutions.
 

--- a/scaffold-exercises/SKILL.md
+++ b/scaffold-exercises/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: scaffold-exercises
+description: Create exercise directory structures that pass ai-hero-cli lint validation. Handles section and exercise naming, variants (problem/solution/explainer), readme stubs, and proper numbering conventions. Use when user wants to scaffold exercises, create exercise directories, or set up course content structure for ai-hero.
+---
+
 # Scaffold Exercises
 
 Create exercise directory structures that pass `pnpm ai-hero-cli internal lint`.

--- a/tdd/SKILL.md
+++ b/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-description: Test-driven development with red-green-refactor loop. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
+description: Test-driven development using red-green-refactor loop with vertical slices. Writes failing tests first, implements minimal code to pass, then refactors for quality. Use when user wants to build features or fix bugs using TDD, mentions "red-green-refactor", wants integration tests, or asks for test-first development.
 ---
 
 # Test-Driven Development

--- a/write-a-prd/SKILL.md
+++ b/write-a-prd/SKILL.md
@@ -1,4 +1,11 @@
-This skill will be invoked when the user wants to create a PRD. You should go through the steps below. You may skip steps if you don't consider them necessary.
+---
+name: write-a-prd
+description: Create product requirements documents through detailed user interviews, codebase exploration, module identification, and structured documentation. Produces PRDs with problem statements, user stories, implementation decisions, and testing strategy as GitHub issues. Use when user wants to write a PRD, create product requirements, or document a feature specification.
+---
+
+# Write a PRD
+
+Guides the user through creating a PRD via the steps below. Steps may be skipped if not necessary.
 
 1. Ask the user for a long, detailed description of the problem they want to solve and any potential ideas for solutions.
 

--- a/write-a-skill/SKILL.md
+++ b/write-a-skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: write-a-skill
-description: Create new agent skills with proper structure, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.
+description: Create new agent skills with proper YAML frontmatter, structured workflows, progressive disclosure, and bundled resources. Use when user wants to create, write, or build a new skill.
 ---
 
 # Writing Skills


### PR DESCRIPTION
Hullo @mattpocock 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/983bd384-12ab-444a-be93-0cf23feb52db" />

Here's the before/after in text form:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| git-guardrails-claude-code | 0% | 100% | +100% | | prd-to-issues | 0% | 100% | +100% |
| scaffold-exercises | 0% | 100% | +100% |
| grill-me | 0% | 93% | +93% |
| obsidian-vault | 0% | 94% | +94% |
| write-a-prd | 0% | 86% | +86% |
| edit-article | 21% | 83% | +62% |
| request-refactor-plan | 50% | 86% | +36% |
| design-an-interface | 84% | 100% | +16% |
| write-a-skill | 95% | 100% | +5% |
| tdd | 88% | 85% | -3% |
| migrate-to-shoehorn | 86% | 86% | 0% |
| prd-to-plan | 100% | 100% | 0% |
| setup-pre-commit | 100% | 100% | 0% |

<details>
<summary>What changed</summary>

**Skills that were scoring 0% (missing frontmatter)**

Six skills (grill-me, obsidian-vault, prd-to-issues, scaffold-exercises, write-a-prd, git-guardrails-claude-code) were failing validation because they lacked YAML frontmatter with `name` and `description` fields. Added frontmatter with specific, third-person descriptions including "Use when..." trigger clauses so agents can properly discover and select these skills.

- **git-guardrails-claude-code**: Also renamed the `name` field from `git-guardrails-claude-code` to `git-guardrails` since "claude" is a reserved word that causes validation failure
- **grill-me**: Added structured workflow (understand plan → probe branches → resolve dependencies → confirm understanding) to the previously one-line body
- **write-a-prd**: Rewrote first-person opening ("This skill will be invoked...") to third-person voice and added a heading

**Skills with low scores**

- **edit-article** (21% → 83%): Replaced vague description ("help them edit an article") with specific capabilities. Added heading and structured workflow sections.
- **request-refactor-plan** (50% → 86%): Expanded the one-line description with concrete capabilities (problem exploration, codebase verification, tiny commits). Rewrote first-person voice to third-person.

**Already-good skills (minor description improvements)**

- **design-an-interface** (84% → 100%): Added "compare trade-offs, and synthesize the best approach" to description for better specificity
- **tdd** (88% → 85%): Added concrete actions ("Writes failing tests first, implements minimal code to pass, then refactors") to description. The -3% is LLM judge variance on the unchanged body — the description itself improved from 90% to 100%.
- **write-a-skill** (95% → 100%): Added "YAML frontmatter, structured workflows" to description for specificity

</details>

Honest disclosure — I work at @tesslio where we build tooling around skills like these. Not a pitch - just saw room for improvement and wanted to contribute.

Want to self-improve your skills? Just point your agent (Claude Code, Codex, etc.) at [this Tessl guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and ask it to optimize your skill. Ping me - [@popey](https://github.com/popey) - if you hit any snags.

Thanks in advance 🙏