### PR TITLE
feat: add native Claude Code marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "mattpocock",
+  "plugins": [
+    {
+      "name": "skills",
+      "description": "All 16 of Matt Pocock's production-grade Claude Code skills.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./design-an-interface",
+        "./edit-article",
+        "./git-guardrails-claude-code",
+        "./grill-me",
+        "./improve-codebase-architecture",
+        "./migrate-to-shoehorn",
+        "./obsidian-vault",
+        "./prd-to-issues",
+        "./prd-to-plan",
+        "./request-refactor-plan",
+        "./scaffold-exercises",
+        "./setup-pre-commit",
+        "./tdd",
+        "./triage-issue",
+        "./write-a-prd",
+        "./write-a-skill"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 A collection of agent skills that extend capabilities across planning, development, and tooling.
 
+## Installation
+
+You can install these skills directly into Claude Code using the native marketplace:
+
+```bash
+# 1. Register the marketplace
+/plugin marketplace add mattpocock/skills
+
+# 2. Install all skills
+/plugin install skills@mattpocock
+```
+
 ## Planning & Design
 
 These skills help you think through problems before writing code.


### PR DESCRIPTION
This PR adds a static \.claude-plugin/marketplace.json\ manifest. This allows users to organically discover and install all 16 of the provided skills directly through Claude Code's native \/plugin install marketplace\ and \/plugin install skills@mattpocock\ commands without manual script execution or copying folders, fully solving #3.