### PR TITLE
Improve grill-me guidance and broaden its sweet spot

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ These skills help you think through problems before writing code.
   npx skills@latest add mattpocock/skills/prd-to-issues
   ```
 
-- **grill-me** — Get relentlessly interviewed about a plan or design until every branch of the decision tree is resolved.
+- **grill-me** — Stress-test a plan, design, strategy, process, or important decision until the key branches, trade-offs, and open questions are clear.
 
   ```
   npx skills@latest add mattpocock/skills/grill-me

--- a/grill-me/SKILL.md
+++ b/grill-me/SKILL.md
@@ -1,8 +1,21 @@
 ---
 name: grill-me
-description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+description: Interview the user about a plan, design, strategy, process, or important decision until reaching shared understanding and surfacing the major assumptions, trade-offs, and open questions. Use when the user wants to stress-test a plan, get grilled on their thinking, or mentions "grill me".
 ---
 
-Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+Interview me about this idea until we reach a shared understanding. Walk down the key branches of the decision tree, resolve dependencies one-by-one, and help surface the assumptions that matter.
 
-If a question can be answered by exploring the codebase, explore the codebase instead.
+## How to run this skill
+
+- If the idea is still too vague to grill, first ask the user for a rough plan in 3-5 bullets.
+- Ask one high-leverage question at a time. If batching helps, ask only a small, easy-to-answer set.
+- Prioritize questions about goals, constraints, scope, trade-offs, dependencies, risks, and failure modes.
+- For each question, provide your recommended answer when you have one.
+- If a question can be answered by exploring the codebase, docs, or prior context, explore those first instead of asking.
+- You can use this outside programming too: strategy, writing, interviews, operations, business ideas, and other decisions with real trade-offs.
+- Stop once the core goal, constraints, major decisions, and biggest risks are clear enough to move forward.
+- Always end with a short summary covering:
+  - what we decided
+  - what is still open
+  - the biggest remaining risk
+  - the recommended next step


### PR DESCRIPTION
## Summary

This keeps `grill-me` lightweight, but makes it more consistent and more broadly useful.

### Changes
- broaden the positioning from just plans/designs to also include strategy, process, and important decisions
- tell the model to ask one high-leverage question at a time, or only a small easy-to-answer batch
- add a clear instruction to stop once the core goal, constraints, major decisions, and biggest risks are clear
- always end with a short summary of decisions, open questions, biggest risk, and recommended next step
- mention that the skill is also useful outside programming

## Why

The current version is powerful but underspecified. In practice, a little more guidance helps it land in the sweet spot without turning it into a giant framework.

This also addresses a couple of open issues:
- #16
- #18

I intentionally kept the change small and prompt-level only.