### PR TITLE
Add marketplace.json for plugin discovery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,158 @@
+{
+  "name": "mattpocock-skills",
+  "owner": {
+    "name": "Matt Pocock"
+  },
+  "metadata": {
+    "description": "A collection of agent skills that extend capabilities across planning, development, and tooling."
+  },
+  "plugins": [
+    {
+      "name": "to-prd",
+      "source": "./to-prd",
+      "description": "Turn the current conversation context into a PRD and submit it as a GitHub issue. No interview - just synthesizes what you've already discussed.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "to-issues",
+      "source": "./to-issues",
+      "description": "Break any plan, spec, or PRD into independently-grabbable GitHub issues using vertical slices.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "grill-me",
+      "source": "./grill-me",
+      "description": "Get relentlessly interviewed about a plan or design until every branch of the decision tree is resolved.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "design-an-interface",
+      "source": "./design-an-interface",
+      "description": "Generate multiple radically different interface designs for a module using parallel sub-agents.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "request-refactor-plan",
+      "source": "./request-refactor-plan",
+      "description": "Create a detailed refactor plan with tiny commits via user interview, then file it as a GitHub issue.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "domain-model",
+      "source": "./domain-model",
+      "description": "Grilling session that challenges your plan against the existing domain model, sharpens terminology, and updates documentation (CONTEXT.md, ADRs) inline as decisions crystallise.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "ubiquitous-language",
+      "source": "./ubiquitous-language",
+      "description": "Extract a DDD-style ubiquitous language glossary from the current conversation.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "zoom-out",
+      "source": "./zoom-out",
+      "description": "Tell the agent to zoom out and give broader context or a higher-level perspective. Use when you're unfamiliar with a section of code or need to understand how it fits into the bigger picture.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "tdd",
+      "source": "./tdd",
+      "description": "Test-driven development with a red-green-refactor loop. Builds features or fixes bugs one vertical slice at a time.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "triage-issue",
+      "source": "./triage-issue",
+      "description": "Investigate a bug by exploring the codebase, identify the root cause, and file a GitHub issue with a TDD-based fix plan.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "github-triage",
+      "source": "./github-triage",
+      "description": "Triage GitHub issues through a label-based state machine with interactive grilling sessions. Use when reviewing incoming bugs or feature requests, or preparing issues for an AFK agent.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "qa",
+      "source": "./qa",
+      "description": "Interactive QA session where user reports bugs or issues conversationally, and the agent files GitHub issues. Explores the codebase in the background for context and domain language.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "improve-codebase-architecture",
+      "source": "./improve-codebase-architecture",
+      "description": "Explore a codebase for architectural improvement opportunities, focusing on deepening shallow modules and improving testability.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "migrate-to-shoehorn",
+      "source": "./migrate-to-shoehorn",
+      "description": "Migrate test files from `as` type assertions to @total-typescript/shoehorn.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "scaffold-exercises",
+      "source": "./scaffold-exercises",
+      "description": "Create exercise directory structures with sections, problems, solutions, and explainers.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "setup-pre-commit",
+      "source": "./setup-pre-commit",
+      "description": "Set up Husky pre-commit hooks with lint-staged, Prettier, type checking, and tests.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "git-guardrails-claude-code",
+      "source": "./git-guardrails-claude-code",
+      "description": "Set up Claude Code hooks to block dangerous git commands (push, reset --hard, clean, etc.) before they execute.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "write-a-skill",
+      "source": "./write-a-skill",
+      "description": "Create new skills with proper structure, progressive disclosure, and bundled resources.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "edit-article",
+      "source": "./edit-article",
+      "description": "Edit and improve articles by restructuring sections, improving clarity, and tightening prose.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "obsidian-vault",
+      "source": "./obsidian-vault",
+      "description": "Search, create, and manage notes in an Obsidian vault with wikilinks and index notes.",
+      "strict": false,
+      "skills": ["./"]
+    },
+    {
+      "name": "caveman",
+      "source": "./caveman",
+      "description": "Ultra-compressed communication mode. Cuts token usage ~75% by dropping filler, articles, and pleasantries while keeping full technical accuracy.",
+      "strict": false,
+      "skills": ["./"]
+    }
+  ]
+}


### PR DESCRIPTION
Makes the repo installable via `/plugin marketplace add` in Claude Code. Each of the 21 existing skill directories is exposed as a separate plugin entry so users can install them individually. Uses strict: false with skills: ["./"] so no changes to the current skill directory layout are required.