### PR TITLE
Make the write-a-skill line-limit consistent

### DIFF
--- a/write-a-skill/SKILL.md
+++ b/write-a-skill/SKILL.md
@@ -101,7 +101,7 @@ Scripts save tokens and improve reliability vs generated code.
 
 Split into separate files when:
 
-- SKILL.md exceeds 100 lines
+- SKILL.md exceeds 500 lines
 - Content has distinct domains (finance vs sales schemas)
 - Advanced features are rarely needed
 
@@ -110,7 +110,7 @@ Split into separate files when:
 After drafting, verify:
 
 - [ ] Description includes triggers ("Use when...")
-- [ ] SKILL.md under 100 lines
+- [ ] SKILL.md under 500 lines
 - [ ] No time-sensitive info
 - [ ] Consistent terminology
 - [ ] Concrete examples included


### PR DESCRIPTION
The write-a-skill skill has conflicting line-length restrictions:

https://github.com/mattpocock/skills/blob/8868f54212dfcf450b665d2e2a5bf521ada64c3e/write-a-skill/SKILL.md?plain=1#L18

https://github.com/mattpocock/skills/blob/8868f54212dfcf450b665d2e2a5bf521ada64c3e/write-a-skill/SKILL.md?plain=1#L102-L104

https://github.com/mattpocock/skills/blob/8868f54212dfcf450b665d2e2a5bf521ada64c3e/write-a-skill/SKILL.md?plain=1#L113

This PR sets all of them to a 500 [as suggested on agentskills.io](https://agentskills.io/skill-creation/best-practices#structure-large-skills-with-progressive-disclosure).