### PR TITLE
feat: support native GitHub sub-issues for /to-issues skill

### DIFF
--- a/to-issues/SKILL.md
+++ b/to-issues/SKILL.md
@@ -51,6 +51,10 @@ Iterate until the user approves the breakdown.
 
 For each approved slice, create a GitHub issue using `gh issue create`. Use the issue body template below.
 
+child_id=$(gh api repos/:owner/:repo/issues/<child_number> -q .id)
+gh api -X POST repos/:owner/:repo/issues/<parent-issue-number>/sub_issues -F sub_issue_id=$child_id
+```"
+
 Create issues in dependency order (blockers first) so you can reference real issue numbers in the "Blocked by" field.
 
 <issue-template>


### PR DESCRIPTION
This PR addresses issue #47 by updating the instructions for the `/to-issues` skill. 

Instead of only referencing the parent issue in the body text, it now includes the necessary API commands to link issues as native sub-issues using the GitHub REST API.

Closes #47