### PR TITLE
fix: support both bun.lock and bun.lockb for Bun detection

### DIFF
--- a/setup-pre-commit/SKILL.md
+++ b/setup-pre-commit/SKILL.md
@@ -16,7 +16,7 @@ description: Set up Husky pre-commit hooks with lint-staged (Prettier), type che
 
 ### 1. Detect package manager
 
-Check for `package-lock.json` (npm), `pnpm-lock.yaml` (pnpm), `yarn.lock` (yarn), `bun.lockb` (bun). Use whichever is present. Default to npm if unclear.
+Check for `package-lock.json` (npm), `pnpm-lock.yaml` (pnpm), `yarn.lock` (yarn), `bun.lock` or `bun.lockb` (bun). Use whichever is present. Default to npm if unclear.
 
 ### 2. Install dependencies
 


### PR DESCRIPTION
## Problem

The `setup-pre-commit` skill currently only checks for `bun.lockb` to detect Bun as the package manager. However, since **Bun v1.1.35**, the default lockfile format changed from the binary `bun.lockb` to the text-based `bun.lock`.

As a result, the skill will fail to identify Bun in modern projects that only have a `bun.lock` file.

## Fix

Update the package manager detection line to check for **both** `bun.lock` (new, text format) and `bun.lockb` (old, binary format), so the skill works correctly regardless of which Bun version the project uses.

## Changes

- `setup-pre-commit/SKILL.md`: Updated package manager detection to list both `bun.lock` and `bun.lockb` as valid Bun lockfile names

Closes #14

Signed-off-by: cocoon <54054995+kuishou68@users.noreply.github.com>