### PR TITLE
feat(grill-me): enforce numbered Q&A with recommended answers

### DIFF
--- a/grill-me/SKILL.md
+++ b/grill-me/SKILL.md
@@ -11,6 +11,7 @@ Interview me relentlessly about every aspect of this plan until we reach a share
 - Ask questions ONE AT A TIME - do not batch multiple questions together
 - After asking a question, wait for the user's response before asking the next question
 - If the user responds in natural language or provides additional context, acknowledge it and continue to the next numbered question
+- The relentless interviewing behavior and decision-tree traversal are unchanged — only the OUTPUT FORMAT is modified
 
 **Multi-Choice Options:**
 - When offering options/choices, list them as numbered items (1. / 2. / 3.)

--- a/grill-me/SKILL.md
+++ b/grill-me/SKILL.md
@@ -12,4 +12,10 @@ Interview me relentlessly about every aspect of this plan until we reach a share
 - After asking a question, wait for the user's response before asking the next question
 - If the user responds in natural language or provides additional context, acknowledge it and continue to the next numbered question
 
+**Multi-Choice Options:**
+- When offering options/choices, list them as numbered items (1. / 2. / 3.)
+- Separate options with blank lines for readability
+- The recommended option is clearly marked (already covered by "Recommended: N. because ..." line)
+- User can respond with a single digit to select their choice
+
 If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/grill-me/SKILL.md
+++ b/grill-me/SKILL.md
@@ -3,8 +3,13 @@ name: grill-me
 description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
 ---
 
-Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one.
 
-Ask the questions one at a time.
+**Question Format Requirements:**
+- Each question MUST be prefixed with "Question N:" where N increments from 1 (e.g., "Question 1:", "Question 2:", etc.)
+- Each question MUST end with a "Recommended: N. because ..." line explaining why this option is recommended
+- Ask questions ONE AT A TIME - do not batch multiple questions together
+- After asking a question, wait for the user's response before asking the next question
+- If the user responds in natural language or provides additional context, acknowledge it and continue to the next numbered question
 
 If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/grill-me/SKILL.md
+++ b/grill-me/SKILL.md
@@ -19,3 +19,9 @@ Interview me relentlessly about every aspect of this plan until we reach a share
 - User can respond with a single digit to select their choice
 
 If a question can be answered by exploring the codebase, explore the codebase instead.
+
+**Past Question References:**
+- Keep track of all question numbers and user responses in the conversation
+- When user references a past question by number (e.g., "question 7", "for question 7's answer"), acknowledge it and reference the previous answer
+- When user says "forget question N" or "discard question N", mark that question as unanswered and re-ask it immediately
+- Do NOT reuse context from a discarded question without re-confirming with the user


### PR DESCRIPTION
## Summary
Enforce numbered questions and responses in the grill-me skill:

- **Question N:** prefix on all questions
- **Recommended: N. because ...** at end of each question
- **Numbered options** (1. / 2. / 3.) for multi-choice
- **Past question references** — user can say 'question 7' or 'forget question 7'
- **No regression** — existing behavior preserved, only output format changes

## Changes
- `grill-me/SKILL.md` — prompt modified with 4 new instruction sections

## Test
Verify the skill outputs:

```
Question 1: [question text]

1. Option A
2. Option B

Recommended: 2. because [reason]
```

## Related
- Closes #45