### PR TITLE
fix(setup-pre-commit): support both bun.lock and bun.lockb for Bun detection

### DIFF
--- a/setup-pre-commit/SKILL.md
+++ b/setup-pre-commit/SKILL.md
@@ -16,7 +16,7 @@ description: Set up Husky pre-commit hooks with lint-staged (Prettier), type che
 
 ### 1. Detect package manager
 
-Check for `package-lock.json` (npm), `pnpm-lock.yaml` (pnpm), `yarn.lock` (yarn), `bun.lockb` (bun). Use whichever is present. Default to npm if unclear.
+Check for `package-lock.json` (npm), `pnpm-lock.yaml` (pnpm), `yarn.lock` (yarn), `bun.lock or bun.lockb` (bun). Use whichever is present. Default to npm if unclear.
 
 ### 2. Install dependencies
 


### PR DESCRIPTION
## Summary

Fixes  Step 1 to detect Bun as package manager for both lockfile formats:
-  — new text format (default since Bun v1.1.35)
-  — old binary format

## Changes

- Line 19: `bun.lockb` → `bun.lock or bun.lockb`

## Checklist

- [x] Acceptance criteria met
- [x] Typecheck passes (N/A — SKILL.md)
- [x] Single-line change, no risk

---

Fixes #14