### PR TITLE
fix: correct bun lockfile extension from bun.lockb to bun.lock

### DIFF
--- a/setup-pre-commit/SKILL.md
+++ b/setup-pre-commit/SKILL.md
@@ -16,7 +16,7 @@ description: Set up Husky pre-commit hooks with lint-staged (Prettier), type che
 
 ### 1. Detect package manager
 
-Check for `package-lock.json` (npm), `pnpm-lock.yaml` (pnpm), `yarn.lock` (yarn), `bun.lockb` (bun). Use whichever is present. Default to npm if unclear.
+Check for `package-lock.json` (npm), `pnpm-lock.yaml` (pnpm), `yarn.lock` (yarn), `bun.lock` (bun). Use whichever is present. Default to npm if unclear.
 
 ### 2. Install dependencies
 


### PR DESCRIPTION
Fixes #14 - corrects the bun lockfile extension from the erroneous `bun.lockb` to the correct `bun.lock`.

The correct lockfile extension for Bun is `bun.lock`, not `bun.lockb`. This is a trivial one-character fix in the `setup-pre-commit` skill's package manager detection logic.