### PR TITLE
feat(to-issues): attach child issues as native sub-issues via API

### DIFF
--- a/to-issues/SKILL.md
+++ b/to-issues/SKILL.md
@@ -76,4 +76,14 @@ Or "None - can start immediately" if no blockers.
 
 </issue-template>
 
+After each `gh issue create`, capture the issue number from the output URL and attach it as a native GitHub sub-issue:
+
+```bash
+child_url=$(gh issue create --title "$title" --body "$body")
+child_num=$(echo "$child_url" | grep -oE '[0-9]+$')
+gh api -X POST repos/OWNER/REPO/issues/<parent-issue-number>/sub_issues -F sub_issue_id=$child_num
+```
+
+This ensures child issues appear in the parent's sub-issue list and progress indicator, not just as text references in the issue body.
+
 Do NOT close or modify any parent issue.


### PR DESCRIPTION
After creating each child issue with `gh issue create`, this PR adds a step to also attach it as a native GitHub sub-issue via the sub-issues REST API.\n\nThis makes child issues appear in the parent's sub-issue list and progress indicator in the GitHub UI, not just as '#\<parent-issue-number\>' text references in the issue body.\n\nFixes #47.