### PR TITLE
docs(link-skills): mark as a dev-only script

### DIFF
--- a/scripts/link-skills.sh
+++ b/scripts/link-skills.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# NOTE: This is a dev-only script, intended for use by maintainers of this repo.
+# It is not a supported installer. Modifications to it — or requests for
+# modifications — will not be approved.
+#
 # Links all skills in the repository into the local skill directories used by
 # each agent harness:
 #   - ~/.claude/skills  — Claude Code


### PR DESCRIPTION
Adds a header note to `scripts/link-skills.sh` clarifying that it is a dev-only script intended for maintainers of this repo, not a supported installer. Modifications to it — or requests for modification — will not be approved.

Closes #389.

🤖 Generated with [Claude Code](https://claude.com/claude-code)