### PR TITLE
Add Task ticket type to decision-mapping skill

### DIFF
--- a/.changeset/decision-mapping-task-type.md
+++ b/.changeset/decision-mapping-task-type.md
@@ -1,0 +1,5 @@
+---
+"mattpocock-skills": minor
+---
+
+Add a fourth **Task** ticket type to the **`decision-mapping`** skill. Some blockers are neither a decision, a prototype, nor research — just literal manual work that has to happen before the discussion can move forward (moving data, signing up for a third-party service, provisioning access). The agent automates it where it can, otherwise hands the human a precise checklist, and records any resulting facts later tickets depend on.

--- a/skills/in-progress/decision-mapping/SKILL.md
+++ b/skills/in-progress/decision-mapping/SKILL.md
@@ -23,7 +23,7 @@ terse enough to stay token-efficient, and unique within the map.
 
 Blocked by: <slug>, <slug>
 Status: open | in-progress | resolved
-Type: Research | Prototype | Grilling
+Type: Research | Prototype | Grilling | Task
 
 ### Question
 
@@ -44,13 +44,12 @@ Each ticket must be sized to one 100K token agent session.
 
 ## Ticket Types
 
-There are three types of tickets:
+There are four types of tickets:
 
 - **Research**: Reading documentation, third-party API's, or local resources like knowledge bases. Creates a markdown summary as an asset. Use this when knowledge outside the current working directory is required.
 - **Prototype**: Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Creates the prototype as an asset. Use this when "how should it look" or "how should it behave" is the key question.
 - **Grilling**: Conversation with the agent. Uses the /grilling and /domain-modeling skills. Asks one question at a time. The default case.
-
-Validation isn't a fourth type — it's the thread running through all three.
+- **Task**: Literal manual work that must be done before the discussion can move forward — nothing to decide, prototype, or research. Moving data from one place to another, signing up for a third-party service, provisioning access. The agent automates it where it can; otherwise it hands the human a precise checklist to do by hand. Resolved when the work is done; the answer records what was done and any resulting facts (credentials location, new URLs, row counts) later tickets depend on.
 
 ## Fog of war
 


### PR DESCRIPTION
Adds a fourth ticket **Task** type to the `decision-mapping` skill.

Some blockers aren't a decision, a prototype, or research — they're just literal manual work that has to happen before the discussion can move forward: moving data from one place to another, signing up for a third-party service, provisioning access. This adds `Task` as a first-class type so the map can represent that work.

- `Type:` enum now includes `Task`
- Ticket Types list updated ("three types" → "four types") with the new entry describing automate-where-possible / hand-off-a-checklist behaviour, and recording resulting facts later tickets depend on
- Removed the standalone "Validation isn't a fourth type" line
- Includes a changeset (minor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)