### PR TITLE
docs: end the build chain at implement, not tdd

### DIFF
--- a/docs/engineering/grill-with-docs.md
+++ b/docs/engineering/grill-with-docs.md
@@ -44,7 +44,7 @@ What makes this variant its own skill is where the answers go. As the grill runs
 `grill-with-docs` is the opening step of the main build chain:
 
 ```txt
-grill-with-docs → to-prd → to-issues → tdd
+grill-with-docs → to-prd → to-issues → implement
 ```
 
 It comes first, before anything is written down as a spec: it produces the shared understanding and settled vocabulary that [to-prd](https://aihero.dev/skills-to-prd) then synthesises into a PRD without re-interviewing you. Its close neighbours are [grilling](https://aihero.dev/skills-grilling), the same interview without the docs, and [domain-modeling](https://aihero.dev/skills-domain-modeling), the glossary-and-ADR discipline it drives. When you're unsure which skill or flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.

--- a/docs/engineering/tdd.md
+++ b/docs/engineering/tdd.md
@@ -38,10 +38,10 @@ Refactoring only happens once the suite is green; never while red.
 
 ## Where it fits
 
-`tdd` is the final step of the main build chain:
+`tdd` is the red-green loop the main build chain runs to write code:
 
 ```txt
-grill-with-docs → to-prd → to-issues → tdd
+grill-with-docs → to-prd → to-issues → implement
 ```
 
-It implements the tickets the earlier steps produced. Its key neighbours are [to-issues](https://aihero.dev/skills-to-issues), which hands it an independently-grabbable issue to build, and [codebase-design](https://aihero.dev/skills-codebase-design), which it leans on to find deep-module seams worth testing at. When you're unsure which skill or flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.
+[implement](https://aihero.dev/skills-implement) is the chain's final step, and it drives `tdd` internally to build each ticket test-first — so `tdd` is the engine inside that step rather than a step of its own. You can also reach for it directly, whenever there's a concrete behaviour to build without a full spec. Its other neighbour is [codebase-design](https://aihero.dev/skills-codebase-design), which it leans on to find deep-module seams worth testing at. When you're unsure which skill or flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.

--- a/docs/engineering/to-issues.md
+++ b/docs/engineering/to-issues.md
@@ -37,7 +37,7 @@ Before slicing, `to-issues` looks for prefactoring — "make the change easy, th
 `to-issues` is a step in the main build chain:
 
 ```txt
-grill-with-docs → to-prd → to-issues → tdd
+grill-with-docs → to-prd → to-issues → implement
 ```
 
-It sits between [to-prd](https://aihero.dev/skills-to-prd), which hands it a settled spec with user stories to slice against, and [tdd](https://aihero.dev/skills-tdd), which implements each independently-grabbable issue test-first. When you're unsure which skill or flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.
+It sits between [to-prd](https://aihero.dev/skills-to-prd), which hands it a settled spec with user stories to slice against, and [implement](https://aihero.dev/skills-implement), which builds each independently-grabbable issue, driving [tdd](https://aihero.dev/skills-tdd) internally to write the tests test-first. When you're unsure which skill or flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.

--- a/docs/engineering/to-prd.md
+++ b/docs/engineering/to-prd.md
@@ -53,7 +53,7 @@ That matters for agentic development: a good interface gives tests something dur
 `to-prd` is a step in the main build chain:
 
 ```txt
-grill-with-docs → to-prd → to-issues → tdd
+grill-with-docs → to-prd → to-issues → implement
 ```
 
-Reach for it after the plan and domain language are resolved, and before you break the work into implementation tickets. Its key neighbours are [grill-with-docs](https://aihero.dev/skills-grill-with-docs), which sharpens the context so the PRD is precise, and [to-issues](https://aihero.dev/skills-to-issues), which turns the PRD into independently-grabbable issues for [tdd](https://aihero.dev/skills-tdd) to implement. When you're unsure which skill or flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.
+Reach for it after the plan and domain language are resolved, and before you break the work into implementation tickets. Its key neighbours are [grill-with-docs](https://aihero.dev/skills-grill-with-docs), which sharpens the context so the PRD is precise, and [to-issues](https://aihero.dev/skills-to-issues), which turns the PRD into independently-grabbable issues for [implement](https://aihero.dev/skills-implement) to build. When you're unsure which skill or flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.


### PR DESCRIPTION
Follow-up to #403 (now merged). Resolves the one open decision from that PR: the canonical build chain's terminal step.

## Decision

The build chain ends at **`implement`**, not `tdd`:

```txt
grill-with-docs → to-prd → to-issues → implement
```

`tdd` is the **red-green loop `implement` drives internally** to build each ticket test-first — the engine inside the final step, not a step of its own. It stays independently reachable (drop to `/tdd` when there's a concrete behaviour to build without a full spec).

This matches what `implement`'s and `ask-matt`'s pages (and the underlying SKILL.md ground truth) already said; #403 left the `to-prd` exemplar and its siblings pointing at `tdd` pending your call.

## Changes

- Chain diagram updated on `grill-with-docs`, `to-prd`, `to-issues`, and `tdd` (was `→ tdd`, now `→ implement`).
- `tdd`'s **Where it fits** reframed: the engine inside the `implement` step, still independently reachable, no longer terminal.
- `to-prd` and `to-issues` now name `implement` as the thing that builds the tickets — giving `implement` the inbound links it previously lacked (it had **zero** before; now three: `to-prd`, `to-issues`, `tdd`).

No SKILL.md draws a chain diagram, so there was no source to contradict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)