### PR TITLE
chore: add implement skill to public plugin set

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,6 +10,7 @@
     "./skills/engineering/tdd",
     "./skills/engineering/to-issues",
     "./skills/engineering/to-prd",
+    "./skills/engineering/implement",
     "./skills/engineering/prototype",
     "./skills/engineering/domain-modeling",
     "./skills/engineering/codebase-design",


### PR DESCRIPTION
Adds the `implement` skill to the published plugin set.

The `implement` skill already existed on disk at `skills/engineering/implement/`, but it was missing from the `skills` array in `.claude-plugin/plugin.json` — the curated list that ships as the `mattpocock-skills` plugin. This adds it so it's included in the public set, slotted after `to-prd` to reflect the PRD → implement flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)