### PR TITLE
feat(wayfinder): make the map collaborative via the issue tracker

### DIFF
--- a/.changeset/wayfinder-collaborative-tracker.md
+++ b/.changeset/wayfinder-collaborative-tracker.md
@@ -1,0 +1,9 @@
+---
+"mattpocock-skills": minor
+---
+
+Make **`wayfinder`** collaborative by moving the map off a local Markdown file and onto the repo's issue tracker.
+
+The map is now a single `wayfinder:map` issue whose tickets are its child issues — one shared URL the whole team can watch and comment on. Blocking, claiming (`wayfinder:claimed`), and the frontier query all use native tracker semantics, so a session loads the map at low resolution (Notes + one context pointer per closed ticket + Fog prose) and zooms into individual tickets on demand, instead of loading the whole map every time.
+
+Wayfinder stays tracker-agnostic: the per-tracker mechanics live behind a pointer in `docs/agents/issue-tracker.md`, so `setup-matt-pocock-skills` now seeds a "Wayfinding operations" section for GitHub, GitLab, and local-markdown. Absent that doc, Wayfinder defaults to local-markdown.

--- a/skills/engineering/setup-matt-pocock-skills/issue-tracker-github.md
+++ b/skills/engineering/setup-matt-pocock-skills/issue-tracker-github.md
@@ -32,3 +32,14 @@ Create a GitHub issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`), plus `wayfinder:claimed` once claimed.
+- **Blocking**: native issue relationships where available; otherwise a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every issue it lists is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open `Blocked by` issue or the `wayfinder:claimed` label; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-label wayfinder:claimed` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/skills/engineering/setup-matt-pocock-skills/issue-tracker-gitlab.md
+++ b/skills/engineering/setup-matt-pocock-skills/issue-tracker-gitlab.md
@@ -33,3 +33,14 @@ Create a GitLab issue.
 ## When a skill says "fetch the relevant ticket"
 
 Run `glab issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `glab issue create --label wayfinder:map`. (On GitLab tiers with native epics, an epic may hold the map instead; a labelled issue works everywhere.)
+- **Child ticket**: an issue carrying `Part of #<map>` at the top of its description and labels `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`), plus `wayfinder:claimed` once claimed.
+- **Blocking**: GitLab's native `/blocked_by #<n>` quick action (or a `Blocked by: #<n>, #<n>` line in the description as fallback). A ticket is unblocked when every issue it lists is closed.
+- **Frontier query**: `glab issue list -F json` scoped to the map's children, drop any with an open blocker or the `wayfinder:claimed` label; first in map order wins.
+- **Claim**: `glab issue update <n> --label wayfinder:claimed` — the session's first write.
+- **Resolve**: `glab issue note <n> --message "<answer>"`, then `glab issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/skills/engineering/setup-matt-pocock-skills/issue-tracker-local.md
+++ b/skills/engineering/setup-matt-pocock-skills/issue-tracker-local.md
@@ -17,3 +17,14 @@ Create a new file under `.scratch/<feature-slug>/` (creating the directory if ne
 ## When a skill says "fetch the relevant ticket"
 
 Read the file at the referenced path. The user will normally pass the path or the issue number directly.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a file with one **child** file per ticket.
+
+- **Map**: `.scratch/<effort>/map.md` — the Notes / Decisions-so-far / Fog body.
+- **Child ticket**: `.scratch/<effort>/issues/NN-<slug>.md`, numbered from `01`, with the question in the body. A `Type:` line records the ticket type (`research`/`prototype`/`grilling`/`task`); a `Status:` line records `claimed`/`resolved`.
+- **Blocking**: a `Blocked by: NN, NN` line near the top. A ticket is unblocked when every file it lists is `resolved`.
+- **Frontier**: scan `.scratch/<effort>/issues/` for files that are open, unblocked, and unclaimed; first by number wins.
+- **Claim**: set `Status: claimed` and save before any work.
+- **Resolve**: append the answer under an `## Answer` heading, set `Status: resolved`, then append a context pointer (gist + link) to the map's Decisions-so-far in `map.md`.

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -59,7 +59,12 @@ The map is _deliberately_ incomplete: don't chart what you can't yet see. Beyond
 
 The map's **Fog** section is where that dim view is written down: the suspected question, the area to revisit later, the risk you're deferring. Write as loosely or as fully as the view allows; it doubles as a signpost for collaborators reading where the effort is headed.
 
-**Fog or ticket?** The test is whether you can state the question precisely now — _not_ whether you can answer it now. A blocked ticket you can't act on yet is still a ticket, because its question is already sharp; fog is what you can't yet phrase that sharply. So don't pre-slice fog into ticket-sized pieces — it's coarser than a ticket, and one patch may graduate into several tickets, or none, once the frontier reaches it. Fog excludes only what's already decided (that's Decisions so far) and what's already a ticket.
+**Fog or ticket?** The test is whether you can state the question precisely now — _not_ whether you can answer it now.
+
+- **Ticket when** the question is already sharp — even if it's blocked and you can't act on it yet.
+- **Fog when** you can't yet phrase it that sharply. Don't pre-slice fog into ticket-sized pieces: it's coarser than a ticket, and one patch may graduate into several tickets, or none, once the frontier reaches it.
+
+Fog excludes only what's already decided (that's Decisions so far) and what's already a ticket.
 
 ## Invocation
 

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -1,59 +1,48 @@
 ---
 name: wayfinder
-description: Chart a route through a foggy problem — turn a loose idea into a map of investigation tickets and resolve them one at a time until the way to the goal is clear.
+description: Chart a route through a foggy problem — turn a loose idea into a shared map of investigation tickets on your issue tracker, and resolve them one at a time until the way to the goal is clear.
 disable-model-invocation: true
 ---
 
-A loose idea has arrived — too big for one agent session, and wrapped in fog: the route from here to a plan isn't visible yet. This skill charts it: stand up a map, then work its tickets one at a time until the way to the goal is clear. The map is domain-agnostic — engineering work, course content, whatever fits the shape.
+A loose idea has arrived — too big for one agent session, and wrapped in fog: the route from here to a plan isn't visible yet. This skill charts it as a **shared map** on the repo's issue tracker, then works its tickets one at a time until the way to the goal is clear. Because the map lives on the tracker, multiple people can watch it, comment on tickets, and pick up the frontier — the chart is a shared artifact, not a private file. The map is domain-agnostic — engineering work, course content, whatever fits the shape.
 
 ## The Map
 
-The map is a single compact Markdown file, one per wayfinding effort, git-tracked alongside the project. It is the canonical artifact — the **whole map is loaded as context into every session**, so it must stay compact.
+The map is a single issue on this repo's issue tracker: one shared object — one URL — that the whole team reads and comments on. It is labelled `wayfinder:map`, and it is the canonical artifact. Its tickets are child issues of the map.
 
-Assets created during tickets should be linked to from the map, not duplicated within it.
+**Where the map, its child tickets, blocking, and frontier queries physically live is tracker-specific.** Consult `docs/agents/issue-tracker.md` (the "Wayfinding operations" section) for how *this* repo expresses them. If that doc is absent, default to the local-markdown tracker.
 
-### Structure
+### The map body
 
-Entries ("tickets"), each its own section keyed by a short dash-case slug that
-reads as a mini-title (e.g. `relational-db`, `auth-strategy`, `cache-layer`) —
-terse enough to stay token-efficient, and unique within the map.
+Three compact zones — this is the whole map at low resolution, loaded once per session:
 
-```markdown
-## relational-db: Relational Or Non-Relational Database?
+- **Notes** — the domain, any skills every session should consult, and freeform standing preferences for this effort.
+- **Decisions so far** — one *context pointer* per closed ticket: a short gist plus a link to the closed issue where the full answer lives. Enough to judge relevance; zoom through the link for detail.
+- **Fog** — terse prose naming what's dimly visible beyond the frontier. Not tickets yet.
 
-Blocked by: <slug>, <slug>
-Status: open | in-progress | resolved
-Type: Research | Prototype | Grilling | Task
+Open tickets are **not** listed here — they are open child issues, found by query.
 
-### Question
+### Tickets
 
-<question-here>
+Each ticket is a **child issue** of the map; the tracker's issue id is its identity. Its body holds the **question**. Two label families:
 
-### Answer
+- `wayfinder:<type>` — one of `research`, `prototype`, `grilling`, `task` (see [Ticket Types](#ticket-types)).
+- `wayfinder:claimed` — a session sets this **first**, before any work, so concurrent sessions skip it.
 
-<answer-here>
-```
+Blocking uses the tracker's native semantics. A ticket is **unblocked** when every ticket blocking it is closed. The **frontier** is the open, unblocked, unclaimed children — the edge of the known.
 
-The slug is the canonical id, used in every `Blocked by` edge and prose
-reference; the title after the colon is optional. A ticket
-is **unblocked** when every ticket in its `Blocked by` list is `resolved`. A
-session **claims** its ticket by setting `Status: in-progress` and saving the map
-before any work, so concurrent sessions skip it.
-
-Each ticket must be sized to one 100K token agent session.
+Each ticket must be sized to one 100K token agent session. Assets created while resolving a ticket are linked from the issue, not pasted into it.
 
 ## Ticket Types
 
-There are four types of tickets:
-
-- **Research**: Reading documentation, third-party API's, or local resources like knowledge bases. Creates a markdown summary as an asset. Use this when knowledge outside the current working directory is required.
-- **Prototype**: Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Creates the prototype as an asset. Use this when "how should it look" or "how should it behave" is the key question.
+- **Research**: Reading documentation, third-party APIs, or local resources like knowledge bases. Creates a markdown summary as a linked asset. Use when knowledge outside the current working directory is required.
+- **Prototype**: Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
 - **Grilling**: Conversation with the agent. Uses the /grilling and /domain-modeling skills. Asks one question at a time. The default case.
-- **Task**: Literal manual work that must be done before the discussion can move forward — nothing to decide, prototype, or research. Moving data from one place to another, signing up for a third-party service, provisioning access. The agent automates it where it can; otherwise it hands the human a precise checklist to do by hand. Resolved when the work is done; the answer records what was done and any resulting facts (credentials location, new URLs, row counts) later tickets depend on.
+- **Task**: Literal manual work that must be done before the discussion can move forward — nothing to decide, prototype, or research. Moving data, signing up for a service, provisioning access. The agent automates it where it can; otherwise it hands the human a precise checklist. Resolved when the work is done; the answer records what was done and any resulting facts (credentials location, new URLs, row counts) later tickets depend on.
 
 ## Fog of war
 
-The map is _deliberately_ incomplete beyond the frontier — don't chart what you can't yet see. The frontier is the unblocked tickets at the edge of the known; resolve them to push it forward. Push back the fog of war one ticket at a time, until the way to the goal is clear and no tickets remain.
+The map is _deliberately_ incomplete beyond the frontier — don't chart what you can't yet see. What is dimly visible but not yet actionable lives as **Fog** prose in the map body, never as speculative tickets; only the frontier becomes real issues. The frontier is the unblocked tickets at the edge of the known; resolve them to push it forward, graduating fog into fresh tickets as it comes into focus. Push back the fog of war one ticket at a time, until the way to the goal is clear and no tickets remain.
 
 ## Invocation
 
@@ -64,45 +53,42 @@ Two branches. Either way, **every session ends with a [Handoff](#handoff)** — 
 User invokes with a loose idea.
 
 1. Run a `/grilling` and `/domain-modeling` session to surface the open decisions.
-2. Write a new map — mostly fog, frontier identified, trivially-decidable entries resolved inline.
-3. Handoff. Charting the map is one session's work; do not also resolve tickets.
+2. **Create the map** (label `wayfinder:map`): Notes filled in, Decisions-so-far empty, Fog sketched.
+3. **Create the frontier tickets** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other).
+4. Leave everything past the frontier as fog — don't chart what you can't see.
+5. Handoff. Charting the map is one session's work; do not also resolve tickets.
 
 ### Work through the map
 
-User invokes with a path to an existing map. A ticket slug is **optional** — without one, you pick the next decision, not the user.
+User invokes with a map (URL or number). A ticket is **optional** — without one, you pick the next decision, not the user.
 
-1. Load the **whole map** as context.
-2. Choose the ticket. If the user named one, use it. Otherwise pick the first `open` ticket in document order that is [unblocked](#structure). [Claim it](#structure): set `Status: in-progress` and save before any work.
-3. Resolve it, invoking skills as needed — including any the `## Notes` block names. If in doubt, use `/grilling` and `/domain-modeling`.
-4. Record the answer in the ticket's body and set `Status: resolved`.
-5. Add newly-discovered tickets with correct `Blocked by` edges. If the decisions made invalidate other parts of the map, update or delete those tickets.
+1. Load the **map** — the low-res view (Notes, decision pointers, fog). Not every ticket body.
+2. Choose the ticket. If the user named one, use it. Otherwise query the frontier and take the first open, unblocked, unclaimed child in order. **Claim it**: set `wayfinder:claimed` and save before any work.
+3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the `## Notes` block names. If in doubt, use `/grilling` and `/domain-modeling`.
+4. Record the resolution: post the answer as a **resolution comment**, **close** the issue, and **append a context pointer** to the map's Decisions-so-far.
+5. Add newly-surfaced frontier tickets (create-then-wire); graduate fog that's now actionable. If the decision invalidates other parts of the map, update or delete those tickets.
 6. Handoff.
 
-The user may run unblocked tickets in parallel, so expect other agents to be editing the map in their own sessions.
+The user may run unblocked tickets in parallel, so expect other sessions to be editing the tracker concurrently.
 
 ## Handoff
 
 End every session by clearing the context and opening one or more fresh sessions. Close with a **Next steps** block the user can copy-paste. Two cases:
 
-**Open tickets remain.** List the currently-unblocked tickets, then give two copy-paste options: a bare command for one session (you pick the next ticket), and one pinned command per unblocked ticket for running them in parallel. Paste one line per fresh window — opening one, some, or all of them.
+**Open tickets remain.** Query the map for the currently-unblocked children, then give two copy-paste options: a bare command for one session (you pick the next ticket), and one pinned command per unblocked ticket for running them in parallel. Paste one line per fresh window — opening one, some, or all of them.
 
-> **Next steps** — 3 tickets unblocked: `auth-strategy`, `cache-layer`, `rate-limits`.
-> Clear the context, then open fresh sessions.
+> **Next steps** — 3 tickets unblocked. Clear the context, then open fresh sessions.
 >
 > **One session** — resolves the next unblocked ticket:
 > ```
-> Invoke /wayfinder with the map at <path>.
+> Invoke /wayfinder with the map <map-url>.
 > ```
 >
 > **Parallel** — paste one line per window, up to all 3:
 > ```
-> Invoke /wayfinder with the map at <path>, ticket auth-strategy.
-> Invoke /wayfinder with the map at <path>, ticket cache-layer.
-> Invoke /wayfinder with the map at <path>, ticket rate-limits.
+> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.
+> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.
+> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.
 > ```
 
 **No open tickets remain.** The fog is pushed back far enough that the way to the goal is clear — the map is done. (The initial grilling may also surface no fog at all, in which case there was never a map to chart.) Recommend implementing directly, or using `/to-prd` to schedule a multi-session implementation.
-
-## Notes
-
-An optional block declaring the **domain**, any skills every session should `consult`, and freeform standing preferences for this effort.

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -4,7 +4,7 @@ description: Chart a route through a foggy problem — turn a loose idea into a 
 disable-model-invocation: true
 ---
 
-A loose idea has arrived — too big for one agent session, and wrapped in fog: the route from here to a plan isn't visible yet. This skill charts it as a **shared map** on the repo's issue tracker, then works its tickets one at a time until the way to the goal is clear. The map is domain-agnostic — engineering work, course content, whatever fits the shape.
+A loose idea has arrived — too big for one agent session, and wrapped in fog: the route from here to a plan isn't visible yet. This skill charts it as a **shared map** on the repo's issue tracker, then works its tickets one at a time. The map is domain-agnostic — engineering work, course content, whatever fits the shape.
 
 ## The Map
 
@@ -42,7 +42,7 @@ Each ticket must be sized to one 100K token agent session. Assets created while 
 
 ## Fog of war
 
-The map is _deliberately_ incomplete beyond the frontier — don't chart what you can't yet see. What is dimly visible but not yet actionable lives as **Fog** prose in the map body, never as speculative tickets; only the frontier becomes real issues. The frontier is the unblocked tickets at the edge of the known; resolve them to push it forward, graduating fog into fresh tickets as it comes into focus. Push back the fog of war one ticket at a time, until the way to the goal is clear and no tickets remain.
+The map is _deliberately_ incomplete beyond the frontier — don't chart what you can't yet see. Only the frontier becomes real tickets; everything dimmer stays fog until it comes into focus. Resolving a frontier ticket pushes the frontier forward, graduating fog into fresh tickets. Push back the fog of war one ticket at a time, until the way to the goal is clear and no tickets remain.
 
 ## Invocation
 
@@ -54,15 +54,15 @@ User invokes with a loose idea.
 
 1. Run a `/grilling` and `/domain-modeling` session to surface the open decisions.
 2. **Create the map** (label `wayfinder:map`): Notes filled in, Decisions-so-far empty, Fog sketched.
-3. **Create the frontier tickets** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Everything past the frontier stays fog.
+3. **Create the frontier tickets** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other).
 4. Handoff. Charting the map is one session's work; do not also resolve tickets.
 
 ### Work through the map
 
 User invokes with a map (URL or number). A ticket is **optional** — without one, you pick the next decision, not the user.
 
-1. Load the **map** — the low-res view (Notes, decision pointers, fog). Not every ticket body.
-2. Choose the ticket. If the user named one, use it. Otherwise query the frontier and take the first open, unblocked, unclaimed child in order. **Claim it**: set `wayfinder:claimed` and save before any work.
+1. Load the **map** — the low-res view, not every ticket body.
+2. Choose the ticket. If the user named one, use it. Otherwise take the first frontier ticket in order. **Claim it**: set `wayfinder:claimed` and save before any work.
 3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the `## Notes` block names. If in doubt, use `/grilling` and `/domain-modeling`.
 4. Record the resolution: post the answer as a **resolution comment**, **close** the issue, and **append a context pointer** to the map's Decisions-so-far.
 5. Add newly-surfaced frontier tickets (create-then-wire); graduate fog that's now actionable. If the decision invalidates other parts of the map, update or delete those tickets.
@@ -72,7 +72,7 @@ The user may run unblocked tickets in parallel, so expect other sessions to be e
 
 ## Handoff
 
-End every session by clearing the context and opening one or more fresh sessions. Close with a **Next steps** block the user can copy-paste. Two cases:
+End every session with a **Next steps** block the user can copy-paste. Two cases:
 
 **Open tickets remain.** Query the map for the currently-unblocked children, then give two copy-paste options: a bare command for one session (you pick the next ticket), and one pinned command per unblocked ticket for running them in parallel. Paste one line per fresh window — opening one, some, or all of them.
 

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -4,11 +4,11 @@ description: Chart a route through a foggy problem — turn a loose idea into a 
 disable-model-invocation: true
 ---
 
-A loose idea has arrived — too big for one agent session, and wrapped in fog: the route from here to a plan isn't visible yet. This skill charts it as a **shared map** on the repo's issue tracker, then works its tickets one at a time until the way to the goal is clear. Because the map lives on the tracker, multiple people can watch it, comment on tickets, and pick up the frontier — the chart is a shared artifact, not a private file. The map is domain-agnostic — engineering work, course content, whatever fits the shape.
+A loose idea has arrived — too big for one agent session, and wrapped in fog: the route from here to a plan isn't visible yet. This skill charts it as a **shared map** on the repo's issue tracker, then works its tickets one at a time until the way to the goal is clear. The map is domain-agnostic — engineering work, course content, whatever fits the shape.
 
 ## The Map
 
-The map is a single issue on this repo's issue tracker: one shared object — one URL — that the whole team reads and comments on. It is labelled `wayfinder:map`, and it is the canonical artifact. Its tickets are child issues of the map.
+The map is a single issue on this repo's issue tracker, labelled `wayfinder:map` — the canonical artifact. Its tickets are child issues of the map.
 
 **Where the map, its child tickets, blocking, and frontier queries physically live is tracker-specific.** Consult `docs/agents/issue-tracker.md` (the "Wayfinding operations" section) for how *this* repo expresses them. If that doc is absent, default to the local-markdown tracker.
 
@@ -54,9 +54,8 @@ User invokes with a loose idea.
 
 1. Run a `/grilling` and `/domain-modeling` session to surface the open decisions.
 2. **Create the map** (label `wayfinder:map`): Notes filled in, Decisions-so-far empty, Fog sketched.
-3. **Create the frontier tickets** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other).
-4. Leave everything past the frontier as fog — don't chart what you can't see.
-5. Handoff. Charting the map is one session's work; do not also resolve tickets.
+3. **Create the frontier tickets** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Everything past the frontier stays fog.
+4. Handoff. Charting the map is one session's work; do not also resolve tickets.
 
 ### Work through the map
 

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -25,7 +25,7 @@ The whole map at low resolution, loaded once per session. Open tickets are **not
 - [<closed ticket title>](<link>) — <one-line gist of the answer>
 
 ## Fog
-<!-- terse prose: what's dimly visible beyond the frontier, not yet tickets -->
+<!-- see "Fog of war" for what belongs here -->
 ```
 
 ### Tickets
@@ -57,7 +57,7 @@ The answer isn't part of the body — it's recorded on resolution (see [Work thr
 
 The map is _deliberately_ incomplete beyond the frontier — don't chart what you can't yet see. Only the frontier becomes real tickets; everything dimmer stays fog until it comes into focus. Resolving a frontier ticket pushes the frontier forward, graduating fog into fresh tickets — one ticket at a time, until the way to the goal is clear and no tickets remain.
 
-The map's **Fog** section is where that dim view is written down: decisions and investigations you can already tell are coming but can't specify yet, because they hang on questions the frontier hasn't answered. Write each as a rough one-liner — the suspected question, the area to revisit later, the risk you're deferring — not a ticket. It doubles as a signpost for collaborators reading where the effort is headed. Keep out what's already decided (that belongs in Decisions so far) and what's actionable now (that becomes a ticket).
+The map's **Fog** section is where that dim view is written down: decisions and investigations you can already tell are coming but can't specify yet, because they hang on questions the frontier hasn't answered — the suspected question, the area to revisit later, the risk you're deferring. Write as loosely or as fully as the view allows; it doubles as a signpost for collaborators reading where the effort is headed. Keep out what's already decided (that belongs in Decisions so far) and what's actionable now (that becomes a ticket).
 
 ## Invocation
 

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -14,24 +14,37 @@ The map is a single issue on this repo's issue tracker, labelled `wayfinder:map`
 
 ### The map body
 
-Three compact zones — this is the whole map at low resolution, loaded once per session:
+The whole map at low resolution, loaded once per session. Open tickets are **not** listed — they are open child issues, found by query.
 
-- **Notes** — the domain, any skills every session should consult, and freeform standing preferences for this effort.
-- **Decisions so far** — one *context pointer* per closed ticket: a short gist plus a link to the closed issue where the full answer lives. Enough to judge relevance; zoom through the link for detail.
-- **Fog** — terse prose naming what's dimly visible beyond the frontier. Not tickets yet.
+```markdown
+## Notes
+<domain; skills every session should consult; standing preferences for this effort>
 
-Open tickets are **not** listed here — they are open child issues, found by query.
+## Decisions so far
+<!-- one context pointer per closed ticket — enough to judge relevance; zoom the link for detail -->
+- [<closed ticket title>](<link>) — <one-line gist of the answer>
+
+## Fog
+<!-- terse prose: what's dimly visible beyond the frontier, not yet tickets -->
+```
 
 ### Tickets
 
-Each ticket is a **child issue** of the map; the tracker's issue id is its identity. Its body holds the **question**. Two label families:
+Each ticket is a **child issue** of the map; the tracker's issue id is its identity. Its body is the question, sized to one 100K token agent session:
+
+```markdown
+## Question
+<the decision or investigation this ticket resolves>
+```
+
+Two label families:
 
 - `wayfinder:<type>` — one of `research`, `prototype`, `grilling`, `task` (see [Ticket Types](#ticket-types)).
 - `wayfinder:claimed` — a session sets this **first**, before any work, so concurrent sessions skip it.
 
 Blocking uses the tracker's native semantics. A ticket is **unblocked** when every ticket blocking it is closed. The **frontier** is the open, unblocked, unclaimed children — the edge of the known.
 
-Each ticket must be sized to one 100K token agent session. Assets created while resolving a ticket are linked from the issue, not pasted into it.
+The answer isn't part of the body — it's recorded on resolution (see [Work through the map](#work-through-the-map)). Assets created while resolving a ticket are linked from the issue, not pasted in.
 
 ## Ticket Types
 

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -55,7 +55,9 @@ The answer isn't part of the body — it's recorded on resolution (see [Work thr
 
 ## Fog of war
 
-The map is _deliberately_ incomplete beyond the frontier — don't chart what you can't yet see. Only the frontier becomes real tickets; everything dimmer stays fog until it comes into focus. Resolving a frontier ticket pushes the frontier forward, graduating fog into fresh tickets. Push back the fog of war one ticket at a time, until the way to the goal is clear and no tickets remain.
+The map is _deliberately_ incomplete beyond the frontier — don't chart what you can't yet see. Only the frontier becomes real tickets; everything dimmer stays fog until it comes into focus. Resolving a frontier ticket pushes the frontier forward, graduating fog into fresh tickets — one ticket at a time, until the way to the goal is clear and no tickets remain.
+
+The map's **Fog** section is where that dim view is written down: decisions and investigations you can already tell are coming but can't specify yet, because they hang on questions the frontier hasn't answered. Write each as a rough one-liner — the suspected question, the area to revisit later, the risk you're deferring — not a ticket. It doubles as a signpost for collaborators reading where the effort is headed. Keep out what's already decided (that belongs in Decisions so far) and what's actionable now (that becomes a ticket).
 
 ## Invocation
 

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -55,9 +55,11 @@ The answer isn't part of the body — it's recorded on resolution (see [Work thr
 
 ## Fog of war
 
-The map is _deliberately_ incomplete beyond the frontier — don't chart what you can't yet see. Only the frontier becomes real tickets; everything dimmer stays fog until it comes into focus. Resolving a frontier ticket pushes the frontier forward, graduating fog into fresh tickets — one ticket at a time, until the way to the goal is clear and no tickets remain.
+The map is _deliberately_ incomplete: don't chart what you can't yet see. Beyond the tickets lies fog — the dim view of decisions and investigations you can tell are coming but can't yet pin down, because they hang on questions still open. Resolving a ticket clears the fog ahead of it, graduating whatever's now specifiable into fresh tickets — one at a time, until the way to the goal is clear and no tickets remain.
 
-The map's **Fog** section is where that dim view is written down: decisions and investigations you can already tell are coming but can't specify yet, because they hang on questions the frontier hasn't answered — the suspected question, the area to revisit later, the risk you're deferring. Write as loosely or as fully as the view allows; it doubles as a signpost for collaborators reading where the effort is headed. Keep out what's already decided (that belongs in Decisions so far) and what's actionable now (that becomes a ticket).
+The map's **Fog** section is where that dim view is written down: the suspected question, the area to revisit later, the risk you're deferring. Write as loosely or as fully as the view allows; it doubles as a signpost for collaborators reading where the effort is headed.
+
+**Fog or ticket?** The test is whether you can state the question precisely now — _not_ whether you can answer it now. A blocked ticket you can't act on yet is still a ticket, because its question is already sharp; fog is what you can't yet phrase that sharply. So don't pre-slice fog into ticket-sized pieces — it's coarser than a ticket, and one patch may graduate into several tickets, or none, once the frontier reaches it. Fog excludes only what's already decided (that's Decisions so far) and what's already a ticket.
 
 ## Invocation
 
@@ -69,7 +71,7 @@ User invokes with a loose idea.
 
 1. Run a `/grilling` and `/domain-modeling` session to surface the open decisions.
 2. **Create the map** (label `wayfinder:map`): Notes filled in, Decisions-so-far empty, Fog sketched.
-3. **Create the frontier tickets** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other).
+3. **Create the tickets you can specify now** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the Fog.
 4. Handoff. Charting the map is one session's work; do not also resolve tickets.
 
 ### Work through the map
@@ -80,7 +82,7 @@ User invokes with a map (URL or number). A ticket is **optional** — without on
 2. Choose the ticket. If the user named one, use it. Otherwise take the first frontier ticket in order. **Claim it**: set `wayfinder:claimed` and save before any work.
 3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the `## Notes` block names. If in doubt, use `/grilling` and `/domain-modeling`.
 4. Record the resolution: post the answer as a **resolution comment**, **close** the issue, and **append a context pointer** to the map's Decisions-so-far.
-5. Add newly-surfaced frontier tickets (create-then-wire); graduate fog that's now actionable. If the decision invalidates other parts of the map, update or delete those tickets.
+5. Add newly-surfaced tickets (create-then-wire); graduate any fog the answer has made specifiable. If the decision invalidates other parts of the map, update or delete those tickets.
 6. Handoff.
 
 The user may run unblocked tickets in parallel, so expect other sessions to be editing the tracker concurrently.


### PR DESCRIPTION
## What

Reworks **`wayfinder`** so the map is a shared artifact on the repo's issue tracker instead of a local Markdown file — the ask was "how do we take that map and put it on an issue tracker" to make it collaborative.

## Design (grilled out beforehand)

- **The map is a single `wayfinder:map` issue**; its tickets are its **child issues**. One shared URL the whole team reads and comments on. "map" is the single leading word — no "epic" jargon layered on top.
- **The map body is the low-res view**, loaded once per session: **Notes** + **Decisions-so-far** (one context pointer per closed ticket → link to the closed issue) + **Fog** (terse prose beyond the frontier). Open tickets aren't listed — they're found by query.
- **Progressive disclosure**: a session lands on one frontier ticket, reads the map, and zooms into related/closed tickets on demand — no more loading the whole map every time.
- **Native tracker semantics** for blocking, claiming (`wayfinder:claimed`, written first), and the frontier query (open + unblocked + unclaimed children).
- **Only the frontier becomes real tickets**; fog stays prose in the map and graduates when actionable.
- **Resolution** = comment the answer, close the issue, append a context pointer to the map.

## Tracker-agnostic seam

Wayfinder delegates all tracker specifics to `docs/agents/issue-tracker.md`. `setup-matt-pocock-skills` now seeds a **"Wayfinding operations"** section (map / child / blocking / frontier / claim / resolve) for **GitHub, GitLab, and local-markdown**. Absent that doc, Wayfinder defaults to local-markdown — so it still works zero-config for a solo idea, and you only run setup when you want the collaborative payoff.

## Not in scope (parked)

- Migrating existing single-file maps.
- Rewiring `to-prd` / `to-plan` to the same map-and-children primitive (the design anticipates it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)