### PR TITLE
fix(wayfinder): rename "Two branches" to "Two modes"

### DIFF
--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -70,7 +70,7 @@ Fog excludes only what's already decided (that's Decisions so far) and what's al
 
 ## Invocation
 
-Two branches. Either way, **every session ends with a [Handoff](#handoff)** — never resolve more than one ticket per session.
+Two modes. Either way, **every session ends with a [Handoff](#handoff)** — never resolve more than one ticket per session.
 
 ### Chart the map
 


### PR DESCRIPTION
## Problem

Reported in #418: the word **branch** in the wayfinder Invocation section throws git-aware agents (Sonnet, GPT-5.5) into eagerly creating **git** branches when the skill runs in an already-established environment. Every subsequent slice of discovery spawns its own branch, which then has to be merged before the next session.

The only occurrence is line 73, `Two branches.`, which introduces the two invocation *modes* — chart the map / work through it. Nothing in the skill involves git, so the word is a pure false cue.

## Fix

`Two branches.` → `Two modes.`

Fixes #418