### PR TITLE
Add claude-handoff skill (in-progress)

### DIFF
--- a/skills/in-progress/README.md
+++ b/skills/in-progress/README.md
@@ -8,3 +8,4 @@ Skills that are still being developed. They're not ready to ship — expect roug
 - **[writing-beats](./writing-beats/SKILL.md)** — Shape an article as a journey of beats, choose-your-own-adventure style. Pick a starting beat, write only that beat, then pivot to the next, until the article reaches a natural end.
 - **[writing-fragments](./writing-fragments/SKILL.md)** — Grilling session that mines you for fragments — heterogeneous nuggets of writing — and appends them to a single document as raw material for a future article.
 - **[writing-shape](./writing-shape/SKILL.md)** — Take a markdown file of raw material and shape it into an article paragraph by paragraph, arguing format choices at each step.
+- **[claude-handoff](./claude-handoff/SKILL.md)** — Hand the current conversation off to a fresh background agent that picks up the work immediately, seeded with a handoff summary via `claude --bg`. User-invoked.

--- a/skills/in-progress/claude-handoff/SKILL.md
+++ b/skills/in-progress/claude-handoff/SKILL.md
@@ -5,7 +5,9 @@ argument-hint: "What will the next session be used for?"
 disable-model-invocation: true
 ---
 
-Write a handoff document summarising the current conversation so a fresh agent can continue the work. Instead of saving it, launch a background agent seeded with the document as its prompt: `claude --bg "<handoff document>"`. It starts in the current working directory and returns immediately; the user manages it with `claude agents`.
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Instead of saving it, launch a background agent seeded with the document as its prompt: `claude --bg --name "<descriptive name>" "<handoff document>"`. It starts in the current working directory and returns immediately; the user manages it with `claude agents`.
+
+Always pass `-n`/`--name` with a descriptive name (e.g. `--name "Fix login bug"`) — it sets the display name shown in the job list, session picker, and terminal title.
 
 Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
 

--- a/skills/in-progress/claude-handoff/SKILL.md
+++ b/skills/in-progress/claude-handoff/SKILL.md
@@ -5,14 +5,14 @@ argument-hint: "What will the next session be used for?"
 disable-model-invocation: true
 ---
 
-Write a handoff document summarising the current conversation so a fresh agent can continue the work. Instead of saving it, launch a background agent seeded with the document as its prompt: `claude --bg --name "<descriptive name>" "<handoff document>"`. It starts in the current working directory and returns immediately; the user manages it with `claude agents`.
+Write a handoff summary of the current conversation so a fresh agent can continue the work. Instead of saving it, launch a background agent seeded with the summary as its prompt: `claude --bg --name "<descriptive name>" "<handoff summary>"`. It starts in the current working directory and returns immediately; the user manages it with `claude agents`.
 
 Always pass `-n`/`--name` with a descriptive name (e.g. `--name "Fix login bug"`) — it sets the display name shown in the job list, session picker, and terminal title.
 
-Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
+Include a "suggested skills" section in the summary, which suggests skills that the agent should invoke.
 
 Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
 
-Redact any sensitive information, such as API keys, passwords, or personally identifiable information — the document becomes the agent's prompt.
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information — the summary becomes the agent's prompt.
 
-If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the summary accordingly.

--- a/skills/in-progress/claude-handoff/SKILL.md
+++ b/skills/in-progress/claude-handoff/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: claude-handoff
+description: Hand off the current conversation to a fresh background agent that picks up the work immediately.
+argument-hint: "What will the next session be used for?"
+disable-model-invocation: true
+---
+
+Compose a handoff summarising the current conversation so a fresh agent can continue the work, then launch it as a background agent seeded with that summary — do not save a document.
+
+Launch with `claude --bg "<summary>"`, passing the summary as the prompt. It starts in the current working directory and returns immediately; the user manages it with `claude agents`.
+
+Include a "suggested skills" section in the summary, instructing the agent which skills to invoke.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information — it becomes the agent's prompt.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the summary accordingly.

--- a/skills/in-progress/claude-handoff/SKILL.md
+++ b/skills/in-progress/claude-handoff/SKILL.md
@@ -1,18 +1,16 @@
 ---
 name: claude-handoff
-description: Hand off the current conversation to a fresh background agent that picks up the work immediately.
+description: Hand the current conversation off to a fresh background agent that picks up the work immediately.
 argument-hint: "What will the next session be used for?"
 disable-model-invocation: true
 ---
 
-Compose a handoff summarising the current conversation so a fresh agent can continue the work, then launch it as a background agent seeded with that summary — do not save a document.
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Instead of saving it, launch a background agent seeded with the document as its prompt: `claude --bg "<handoff document>"`. It starts in the current working directory and returns immediately; the user manages it with `claude agents`.
 
-Launch with `claude --bg "<summary>"`, passing the summary as the prompt. It starts in the current working directory and returns immediately; the user manages it with `claude agents`.
-
-Include a "suggested skills" section in the summary, instructing the agent which skills to invoke.
+Include a "suggested skills" section in the document, which suggests skills that the agent should invoke.
 
 Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
 
-Redact any sensitive information, such as API keys, passwords, or personally identifiable information — it becomes the agent's prompt.
+Redact any sensitive information, such as API keys, passwords, or personally identifiable information — the document becomes the agent's prompt.
 
-If the user passed arguments, treat them as a description of what the next session will focus on and tailor the summary accordingly.
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.


### PR DESCRIPTION
New user-invoked skill `claude-handoff`, placed in `skills/in-progress/`.

Identical to the existing `handoff` skill, with one substantive difference: instead of saving the conversation summary to a markdown file, it hands the summary straight to a fresh background agent as its seed prompt via `claude --bg "<summary>"` (which starts in the current cwd and returns immediately; managed with `claude agents`).

Preserves handoff's suggested-skills section, don't-duplicate-artifacts rule, redaction rule (now noting the summary becomes the agent's prompt), and arg-tailoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)