### PR TITLE
wayfinder: refer to maps and tickets by name, not id

### DIFF
--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -7,7 +7,7 @@ A loose idea has arrived — too big for one agent session, and wrapped in fog: 
 
 ## Refer by name
 
-Every map and ticket is an issue, so it has a **name** — its title. In everything the human reads — narration, the map's Decisions-so-far, the Handoff — refer to it by that name, never by a bare id, number, or slug. A wall of `#42, #43, #44` is illegible at a glance; names read instantly. The id and URL stay the identity: the link a name wraps, the pasteable handle in a command — they ride *inside* the name, never stand in for it.
+Every map and ticket is an issue, so it has a **name** — its title. In everything the human reads — narration, the map's Decisions-so-far, the Handoff — refer to it by that name, never by a bare id, number, or slug. A wall of `#42, #43, #44` is illegible; names read at a glance. The id and URL don't vanish — a name wraps its link, and Handoff commands still paste the URL — but they ride *inside* the name, never stand in for it.
 
 ## The Map
 

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -108,7 +108,7 @@ End every session with a **Next steps** block the user can copy-paste. Two cases
 
 **Open tickets remain.** Query the map for the currently-unblocked children, then give two copy-paste options: a bare command for one session (you pick the next ticket), and one pinned command per unblocked ticket for running them in parallel. Paste one line per fresh window — opening one, some, or all of them.
 
-> **Next steps** — *Briefing pipeline*: 3 tickets unblocked. Clear the context, then open fresh sessions.
+> **Next steps** — *<map name>*: 3 tickets unblocked. Clear the context, then open fresh sessions.
 >
 > **One session** — resolves the next unblocked ticket:
 >
@@ -116,12 +116,12 @@ End every session with a **Next steps** block the user can copy-paste. Two cases
 > Invoke /wayfinder with the map <map-url>.
 > ```
 >
-> **Parallel** — paste one line per window, up to all 3 (trailing name orients you; it's ignored on paste):
+> **Parallel** — paste one line per window, up to all 3:
 >
 > ```
-> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # Reciprocity filter
-> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # TTS chunking
-> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # Voice selection
+> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # <ticket name>
+> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # <ticket name>
+> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # <ticket name>
 > ```
 
 **No open tickets remain.** The fog is pushed back far enough that the way to the goal is clear — the map is done. (The initial grilling may also surface no fog at all, in which case there was never a map to chart.) Recommend implementing directly, or using `/to-prd` to schedule a multi-session implementation.

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -5,6 +5,10 @@ description: Chart a route through a foggy problem — turn a loose idea into a 
 
 A loose idea has arrived — too big for one agent session, and wrapped in fog: the route from here to a plan isn't visible yet. This skill charts it as a **shared map** on the repo's issue tracker, then works its tickets one at a time. The map is domain-agnostic — engineering work, course content, whatever fits the shape.
 
+## Refer by name
+
+Every map and ticket is an issue, so it has a **name** — its title. In everything the human reads — narration, the map's Decisions-so-far, the Handoff — refer to it by that name, never by a bare id, number, or slug. A wall of `#42, #43, #44` is illegible at a glance; names read instantly. The id and URL stay the identity: the link a name wraps, the pasteable handle in a command — they ride *inside* the name, never stand in for it.
+
 ## The Map
 
 The map is a single issue on this repo's issue tracker, labelled `wayfinder:map` — the canonical artifact. Its tickets are child issues of the map.
@@ -104,7 +108,7 @@ End every session with a **Next steps** block the user can copy-paste. Two cases
 
 **Open tickets remain.** Query the map for the currently-unblocked children, then give two copy-paste options: a bare command for one session (you pick the next ticket), and one pinned command per unblocked ticket for running them in parallel. Paste one line per fresh window — opening one, some, or all of them.
 
-> **Next steps** — 3 tickets unblocked. Clear the context, then open fresh sessions.
+> **Next steps** — *Briefing pipeline*: 3 tickets unblocked. Clear the context, then open fresh sessions.
 >
 > **One session** — resolves the next unblocked ticket:
 >
@@ -112,12 +116,12 @@ End every session with a **Next steps** block the user can copy-paste. Two cases
 > Invoke /wayfinder with the map <map-url>.
 > ```
 >
-> **Parallel** — paste one line per window, up to all 3:
+> **Parallel** — paste one line per window, up to all 3 (trailing name orients you; it's ignored on paste):
 >
 > ```
-> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.
-> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.
-> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.
+> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # Reciprocity filter
+> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # TTS chunking
+> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # Voice selection
 > ```
 
 **No open tickets remain.** The fog is pushed back far enough that the way to the goal is clear — the map is done. (The initial grilling may also surface no fog at all, in which case there was never a map to chart.) Recommend implementing directly, or using `/to-prd` to schedule a multi-session implementation.


### PR DESCRIPTION
## What

Adds a **Refer by name** convention to the Wayfinder skill: maps and tickets are surfaced by their human-friendly title (the issue title) in everything the human reads — narration, the map's Decisions-so-far, and the Handoff — rather than by bare ids, numbers, or slugs.

## Why

A wall of `#42, #43, #44` is illegible at a glance; names read instantly. The id/URL still matters as identity and as the pasteable handle in Handoff commands, so the rule is "name is the reference, id rides *inside* it" — not "drop ids."

## Changes

- New `## Refer by name` section stating the convention as a global standing rule (it applies everywhere the agent produces human-facing text).
- Handoff example updated to demonstrate it: the map is named in the header, and each parallel command is annotated with its ticket name so the human can tell the windows apart while the URL stays pasteable.

Single source of truth: `name` is defined once; Decisions-so-far already links by title, so the rule generalizes an existing pattern rather than restating it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)