### PR TITLE
wayfinder: recheck claims before showing the frontier in Handoff

### DIFF
--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -104,7 +104,9 @@ The user may run unblocked tickets in parallel, so expect other sessions to be e
 
 ## Handoff
 
-End every session with a **Next steps** block the user can copy-paste. Two cases:
+**Recheck your claims first.** Before you show the frontier, reread every assertion you're about to hand off — the resolution answer, the Decisions-so-far line you appended, any facts later tickets will depend on — against the actual tracker state and the assets you linked, and fix whatever doesn't hold. The available sessions and the new frontier the human is about to act on are only as sound as the claims underneath them.
+
+Then end every session with a **Next steps** block the user can copy-paste. Two cases:
 
 **Open tickets remain.** Query the map for the currently-unblocked children, then give two copy-paste options: a bare command for one session (you pick the next ticket), and one pinned command per unblocked ticket for running them in parallel. Paste one line per fresh window — opening one, some, or all of them.
 


### PR DESCRIPTION
## What

Adds a **Recheck your claims first** gate at the top of Wayfinder's `Handoff` section, before the *Next steps* block that reveals which sessions are available and the new frontier.

## Why

The Handoff is the session's final output, and its *Next steps* block hands the human an actionable frontier derived from the tracker state the session just wrote. Previously nothing prompted the agent to re-verify its own map edits — it could write the handoff straight from memory. This gate rereads the assertions being handed off (the resolution answer, the appended Decisions-so-far line, and facts later tickets depend on) against the actual tracker state and linked assets, and fixes whatever doesn't hold, so the frontier the human acts on is trustworthy.

Placed as a single gate at the top of `Handoff` because both surfaces named — available sessions and the new frontier — are downstream of the same just-written tracker state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)