### PR TITLE
wayfinder: remove the Handoff ceremony

### DIFF
--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -7,7 +7,7 @@ A loose idea has arrived — too big for one agent session, and wrapped in fog: 
 
 ## Refer by name
 
-Every map and ticket is an issue, so it has a **name** — its title. In everything the human reads — narration, the map's Decisions-so-far, the Handoff — refer to it by that name, never by a bare id, number, or slug. A wall of `#42, #43, #44` is illegible; names read at a glance. The id and URL don't vanish — a name wraps its link, and Handoff commands still paste the URL — but they ride *inside* the name, never stand in for it.
+Every map and ticket is an issue, so it has a **name** — its title. In everything the human reads — narration, the map's Decisions-so-far — refer to it by that name, never by a bare id, number, or slug. A wall of `#42, #43, #44` is illegible; names read at a glance. The id and URL don't vanish — a name wraps its link — but they ride *inside* the name, never stand in for it.
 
 ## The Map
 
@@ -78,7 +78,7 @@ Fog excludes only what's already decided (that's Decisions so far) and what's al
 
 ## Invocation
 
-Two modes. Either way, **every session ends with a [Handoff](#handoff)** — never resolve more than one ticket per session.
+Two modes. Either way, **never resolve more than one ticket per session.**
 
 ### Chart the map
 
@@ -87,7 +87,7 @@ User invokes with a loose idea.
 1. Run a `/grilling` and `/domain-modeling` session to surface the open decisions.
 2. **Create the map** (label `wayfinder:map`): Notes filled in, Decisions-so-far empty, Fog sketched.
 3. **Create the tickets you can specify now** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the Fog.
-4. Handoff. Charting the map is one session's work; do not also resolve tickets.
+4. Stop — charting the map is one session's work; do not also resolve tickets.
 
 ### Work through the map
 
@@ -98,30 +98,5 @@ User invokes with a map (URL or number). A ticket is **optional** — without on
 3. Resolve it — **zoom as needed**: fetch the full body of any related or closed ticket on demand; invoke the skills the `## Notes` block names. If in doubt, use `/grilling` and `/domain-modeling`.
 4. Record the resolution: post the answer as a **resolution comment**, **close** the issue, and **append a context pointer** to the map's Decisions-so-far.
 5. Add newly-surfaced tickets (create-then-wire); graduate any fog the answer has made specifiable, clearing each graduated patch from the Fog so it lives only as its new ticket. If the decision invalidates other parts of the map, update or delete those tickets.
-6. Handoff.
 
 The user may run unblocked tickets in parallel, so expect other sessions to be editing the tracker concurrently.
-
-## Handoff
-
-End every session with a **Next steps** block the user can copy-paste. Two cases:
-
-**Open tickets remain.** Query the map for the currently-unblocked children, then give two copy-paste options: a bare command for one session (you pick the next ticket), and one pinned command per unblocked ticket for running them in parallel. Paste one line per fresh window — opening one, some, or all of them.
-
-> **Next steps** — *<map name>*: 3 tickets unblocked. Clear the context, then open fresh sessions.
->
-> **One session** — resolves the next unblocked ticket:
->
-> ```
-> Invoke /wayfinder with the map <map-url>.
-> ```
->
-> **Parallel** — paste one line per window, up to all 3:
->
-> ```
-> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # <ticket name>
-> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # <ticket name>
-> Invoke /wayfinder with the map <map-url>, ticket <issue-url>.  # <ticket name>
-> ```
-
-**No open tickets remain.** The fog is pushed back far enough that the way to the goal is clear — the map is done. (The initial grilling may also surface no fog at all, in which case there was never a map to chart.) Recommend implementing directly, or using `/to-prd` to schedule a multi-session implementation.


### PR DESCRIPTION
## What

Removes Wayfinder's `Handoff` section entirely, and reconciles the references left behind.

## Why

Every session ended with a Handoff that queried the frontier and emitted per-ticket copy-paste commands — a real token cost paid every session. This experiments with cutting it completely and letting the natural flow carry continuation: the next `/wayfinder` session already loads the map and picks the next frontier ticket in `Work through the map`, so continuation isn't lost, just deferred to re-invocation.

## What was reconciled / dropped

- **One-ticket-per-session rule** and **"charting is one session's work"** — kept, as plain lines (they weren't part of the ceremony).
- **Refer-by-name** paragraph — dropped its two Handoff mentions.
- **Dropped with the section:** the per-session frontier commands (the token cost this targets), and the one-time terminal signal ("no open tickets → map is done, implement directly or `/to-prd`"). Open question whether that terminal "map done" line is worth re-adding as a lightweight standalone.

Supersedes #424 (which added a recheck gate *inside* the Handoff — moot once the Handoff is gone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)