### PR TITLE
wayfinder: reframe description around planning big work

### DIFF
--- a/.changeset/wayfinder-plan-big-work.md
+++ b/.changeset/wayfinder-plan-big-work.md
@@ -1,0 +1,7 @@
+---
+"mattpocock-skills": minor
+---
+
+Reframe **`wayfinder`**'s description around the work it's for: planning a huge chunk of work, more than one agent session can hold.
+
+The description does the skill's invocation work, so it now leads with the trigger that actually reaches for Wayfinder — a big effort you need to break down — instead of the softer "chart a route through a foggy problem". The skill body and fog-of-war mechanic are unchanged.

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wayfinder
-description: Chart a route through a foggy problem — turn a loose idea into a shared map of investigation tickets on your issue tracker, and resolve them one at a time until the way to the goal is clear.
+description: Plan a huge chunk of work — more than one agent session can hold — as a shared map of investigation tickets on your issue tracker, and resolve them one at a time until the way to the goal is clear.
 ---
 
 A loose idea has arrived — too big for one agent session, and wrapped in fog: the route from here to a plan isn't visible yet. This skill charts it as a **shared map** on the repo's issue tracker, then works its tickets one at a time. The map is domain-agnostic — engineering work, course content, whatever fits the shape.


### PR DESCRIPTION
Reframes the `wayfinder` skill's **description** around the work it's actually for.

**Why:** the description does the skill's invocation work. Leading with the real trigger — a huge chunk of work, more than one agent session can hold — reaches for Wayfinder more reliably than the softer "chart a route through a foggy problem".

**Scope:** description line only. The skill body and the fog-of-war mechanic are untouched — the body describes the process, not a pitch. (An earlier revision of this PR also rewrote the opening paragraph; that's been reverted to keep the body from selling itself.)

Ships with a changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)