### PR TITLE
grilling: add confirmation gate and grill leading word

### DIFF
--- a/.changeset/grilling-gate-and-leading-word.md
+++ b/.changeset/grilling-gate-and-leading-word.md
@@ -1,0 +1,5 @@
+---
+"mattpocock-skills": minor
+---
+
+Add a confirmation gate to **`grilling`**: the agent won't enact the plan until you confirm the shared understanding has been reached, turning the skill's existing "shared understanding" completion criterion into an explicit stop-gate. The `description` also recruits the pretrained **`grill`** leading word ("Grill the user relentlessly") to sharpen invocation, and the docs page is re-synced with the new gate behaviour.

--- a/docs/productivity/grilling.md
+++ b/docs/productivity/grilling.md
@@ -14,7 +14,7 @@ npx skills update grilling
 
 `grilling` is the relentless interview that stress-tests a plan or design before you build it. It walks down the design tree branch by branch, resolving the dependencies between decisions one at a time until you and the agent share the same understanding.
 
-It asks **one question at a time** and waits for your answer before the next — never a bulk list, which is bewildering. Each question comes with the agent's own recommended answer, and any question the codebase can settle it explores instead of asking you.
+It asks **one question at a time** and waits for your answer before the next — never a bulk list, which is bewildering. Each question comes with the agent's own recommended answer, and any question the codebase can settle it explores instead of asking you. It won't start enacting the plan until you confirm the shared understanding has been reached.
 
 ## When to reach for it
 

--- a/skills/productivity/grilling/SKILL.md
+++ b/skills/productivity/grilling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: grilling
-description: Interview the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
+description: Grill the user relentlessly about a plan or design. Use when the user wants to stress-test a plan before building, or uses any 'grill' trigger phrases.
 ---
 
 Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
@@ -8,3 +8,5 @@ Interview me relentlessly about every aspect of this plan until we reach a share
 Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
 
 If a question can be answered by exploring the codebase, explore the codebase instead.
+
+Do not enact the plan until I confirm we have reached a shared understanding.


### PR DESCRIPTION
## What

Two changes to the `grilling` skill (`skills/productivity/grilling`):

1. **Confirmation gate** — new line so the agent won't enact the plan until the user confirms shared understanding has been reached, turning the skill's existing "shared understanding" completion criterion into an explicit stop-gate.
2. **Leading-word pass** — recruit the pretrained `grill` leading word in the `description` (was "Interview the user relentlessly" → "Grill the user relentlessly") to sharpen invocation anchoring. The body keeps "Interview me relentlessly" per request.

Per repo convention (promoted bucket, behaviour change), the docs page `docs/productivity/grilling.md` is re-synced to mention the new gate. `ask-matt` router needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)