### PR TITLE
docs: fix tdd skill reference to code-review skill

### DIFF
--- a/skills/engineering/tdd/SKILL.md
+++ b/skills/engineering/tdd/SKILL.md
@@ -33,4 +33,4 @@ Ask: "What's the public interface, and which seams should we test?"
 
 - **Red before green.** Write the failing test first, then only enough code to pass it. Don't anticipate future tests or add speculative features.
 - **One slice at a time.** One seam, one test, one minimal implementation per cycle.
-- **Refactoring is not part of the loop.** It belongs to the review stage (see the `review` skill), not the red → green implementation cycle.
+- **Refactoring is not part of the loop.** It belongs to the review stage (see the `code-review` skill), not the red → green implementation cycle.


### PR DESCRIPTION
## Summary

The `tdd` skill referenced a `review` skill that no longer exists. The review skill in `skills/engineering/` is now named `code-review`. This updates the dangling reference in `skills/engineering/tdd/SKILL.md` (Rules of the loop → "Refactoring is not part of the loop").

Fixes #432

🤖 Generated with [Claude Code](https://claude.com/claude-code)