### PR TITLE
wayfinder: restore no-fog early exit

### DIFF
--- a/.changeset/wayfinder-no-fog-early-exit.md
+++ b/.changeset/wayfinder-no-fog-early-exit.md
@@ -6,4 +6,4 @@ Restore **`wayfinder`**'s early exit when the frontier grilling turns up no fog.
 
 The skill used to have a **Skipping The Decision Map** section: if the opening grilling surfaced no fog of war, there was no map to build, so it offered to skip straight to implementing. That clause was demoted to a parenthetical inside the Handoff section, then deleted as collateral when Handoff was removed — never an intentional cut.
 
-It's back, co-located in **Chart the map** step 2 (Map the frontier), where the fog/no-fog outcome is actually determined: if breadth-first grilling surfaces no fog, tell the user and offer to skip the map, implementing directly instead. The offer — asking rather than auto-skipping — is preserved from the original.
+It's back, co-located in **Chart the map** step 2 (Map the frontier), where the fog/no-fog outcome is actually determined: if breadth-first grilling surfaces no fog — the journey is small enough for one session — there's no map to justify, so stop and ask the user how they'd like to proceed. The ask, rather than an auto-skip, is preserved from the original.

--- a/.changeset/wayfinder-no-fog-early-exit.md
+++ b/.changeset/wayfinder-no-fog-early-exit.md
@@ -1,0 +1,9 @@
+---
+"mattpocock-skills": patch
+---
+
+Restore **`wayfinder`**'s early exit when the frontier grilling turns up no fog.
+
+The skill used to have a **Skipping The Decision Map** section: if the opening grilling surfaced no fog of war, there was no map to build, so it offered to skip straight to implementing. That clause was demoted to a parenthetical inside the Handoff section, then deleted as collateral when Handoff was removed — never an intentional cut.
+
+It's back, co-located in **Chart the map** step 2 (Map the frontier), where the fog/no-fog outcome is actually determined: if breadth-first grilling surfaces no fog, tell the user and offer to skip the map, implementing directly instead. The offer — asking rather than auto-skipping — is preserved from the original.

--- a/.changeset/wayfinder-no-fog-early-exit.md
+++ b/.changeset/wayfinder-no-fog-early-exit.md
@@ -6,4 +6,4 @@ Restore **`wayfinder`**'s early exit when the frontier grilling turns up no fog.
 
 The skill used to have a **Skipping The Decision Map** section: if the opening grilling surfaced no fog of war, there was no map to build, so it offered to skip straight to implementing. That clause was demoted to a parenthetical inside the Handoff section, then deleted as collateral when Handoff was removed — never an intentional cut.
 
-It's back, co-located in **Chart the map** step 2 (Map the frontier), where the fog/no-fog outcome is actually determined: if breadth-first grilling surfaces no fog — the journey is small enough for one session — there's no map to justify, so stop and ask the user how they'd like to proceed. The ask, rather than an auto-skip, is preserved from the original.
+It's back, co-located in **Chart the map** step 2 (Map the frontier), where the fog/no-fog outcome is actually determined: if breadth-first grilling surfaces no fog — the journey is small enough for one session — you don't need a map, so stop and ask the user how they'd like to proceed. The ask, rather than an auto-skip, is preserved from the original.

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -102,7 +102,7 @@ Two modes. Either way, **never resolve more than one ticket per session.**
 User invokes with a loose idea.
 
 1. **Name the destination.** Run a `/grilling` and `/domain-modeling` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first.
-2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — every decision already takeable, the way to the destination clear — there's nothing to chart: tell the user and offer to skip the map, implementing directly instead.
+2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — the way to the destination is already clear, the whole journey small enough for one session — there's no map to justify. Stop and ask the user how they'd like to proceed.
 3. **Create the map** (label `wayfinder:map`): Destination and Notes filled in, Decisions-so-far empty, the fog sketched into **Not yet specified**.
 4. **Create the tickets you can specify now** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the fog — the **Not yet specified** section.
 5. Stop — charting the map is one session's work; do not also resolve tickets.

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -102,7 +102,7 @@ Two modes. Either way, **never resolve more than one ticket per session.**
 User invokes with a loose idea.
 
 1. **Name the destination.** Run a `/grilling` and `/domain-modeling` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first.
-2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — the way to the destination is already clear, the whole journey small enough for one session — there's no map to justify. Stop and ask the user how they'd like to proceed.
+2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — the way to the destination is already clear, the whole journey small enough for one session — you don't need a map. Stop and ask the user how they'd like to proceed.
 3. **Create the map** (label `wayfinder:map`): Destination and Notes filled in, Decisions-so-far empty, the fog sketched into **Not yet specified**.
 4. **Create the tickets you can specify now** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the fog — the **Not yet specified** section.
 5. Stop — charting the map is one session's work; do not also resolve tickets.

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -102,7 +102,7 @@ Two modes. Either way, **never resolve more than one ticket per session.**
 User invokes with a loose idea.
 
 1. **Name the destination.** Run a `/grilling` and `/domain-modeling` session to pin down what this map is finding its way to — the spec, decision, or change. The destination fixes the scope, so it's settled first.
-2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now.
+2. **Map the frontier.** Grill again, **breadth-first** this time: fan out across the whole space rather than deep on any one thread, surfacing the open decisions and the first steps takeable now. **If this surfaces no fog** — every decision already takeable, the way to the destination clear — there's nothing to chart: tell the user and offer to skip the map, implementing directly instead.
 3. **Create the map** (label `wayfinder:map`): Destination and Notes filled in, Decisions-so-far empty, the fog sketched into **Not yet specified**.
 4. **Create the tickets you can specify now** as child issues of the map — then wire blocking edges in a **second pass** (issues need ids before they can reference each other). Wiring sorts them into the frontier and the blocked; everything you can't yet specify stays in the fog — the **Not yet specified** section.
 5. Stop — charting the map is one session's work; do not also resolve tickets.


### PR DESCRIPTION
## What

Restores wayfinder's early exit for when the opening grilling turns up no fog: if there's nothing to chart, offer to skip the map and implement directly.

## Why

The skill used to have a **Skipping The Decision Map** section doing exactly this. It was demoted to a parenthetical inside the Handoff section, then deleted as collateral when Handoff was removed in `1f16ea9` — never an intentional cut.

## How

Co-located in **Chart the map** step 2 (Map the frontier), where the fog/no-fog outcome is actually determined, reusing the existing **fog** leading word so it adds a branch without adding a concept. The offer — asking rather than auto-skipping — is preserved from the original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)