### PR TITLE
wayfinder/grilling: stop the agent grilling itself

### DIFF
--- a/.changeset/wayfinder-grilling-not-self.md
+++ b/.changeset/wayfinder-grilling-not-self.md
@@ -1,0 +1,12 @@
+---
+"mattpocock-skills": patch
+---
+
+Stop **`wayfinder`** grilling *itself* instead of the human, and classify ticket types by **HITL** / **AFK**.
+
+Students reported `/wayfinder` picking a **grilling** ticket and answering its own questions rather than turning to the human. Root cause: **`grilling`** carried a line written for the live-human case — "If a question can be answered by exploring the codebase, explore the codebase instead" — which, once `wayfinder` runs grilling inside a resolve-the-ticket frame, reads as license to answer questions autonomously and race the ticket to "resolved".
+
+Two changes:
+
+- **`grilling`** now splits *facts* (look them up) from *decisions* (put each one to the human and wait for their answer).
+- **`wayfinder`** labels every ticket type **HITL** (human in the loop — Prototype, Grilling) or **AFK** (agent alone — Research; Task is either). A HITL ticket only resolves through the live exchange, so the "wait for the human" behaviour falls out of the label instead of being spelled out per type — a grilling agent that answers its own questions has, by definition, broken HITL.

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -71,10 +71,12 @@ The answer isn't part of the body — it's recorded on resolution (see [Work thr
 
 ## Ticket Types
 
-- **Research**: Reading documentation, third-party APIs, or local resources like knowledge bases. Creates a markdown summary as a linked asset. Use when knowledge outside the current working directory is required.
-- **Prototype**: Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
-- **Grilling**: Conversation with the agent. Uses the /grilling and /domain-modeling skills. Asks one question at a time. The default case.
-- **Task**: Manual work that must happen before a *decision* can be made — nothing to decide, prototype, or research, but the discussion is blocked until it's done. Signing up for a service so its API can be judged, provisioning access, moving data so its shape can be seen. This is the one type that *does* rather than decides — and it earns its place by unblocking a decision, not by delivering the destination. The agent automates it where it can; otherwise it hands the human a precise checklist. Resolved when the work is done; the answer records what was done and any resulting facts (credentials location, new URLs, row counts) later tickets depend on.
+Every ticket is either **HITL** — human in the loop, worked *with* a human who speaks for themselves — or **AFK**, driven by the agent alone. A HITL ticket only resolves through that live exchange; the agent never stands in for the human's side of it (a grilling agent that answers its own questions has broken this).
+
+- **Research** (AFK): Reading documentation, third-party APIs, or local resources like knowledge bases. Creates a markdown summary as a linked asset. Use when knowledge outside the current working directory is required.
+- **Prototype** (HITL): Raise the fidelity of the discussion by making a cheap, rough, concrete artifact to react to — an outline, a rough take, a stub, or UI/logic code via the /prototype skill. Links the prototype as an asset. Use when "how should it look" or "how should it behave" is the key question.
+- **Grilling** (HITL): Conversation via the /grilling and /domain-modeling skills, one question at a time. The default case.
+- **Task** (HITL or AFK): Manual work that must happen before a *decision* can be made — nothing to decide, prototype, or research, but the discussion is blocked until it's done. Signing up for a service so its API can be judged, provisioning access, moving data so its shape can be seen. This is the one type that *does* rather than decides — and it earns its place by unblocking a decision, not by delivering the destination. The agent drives it alone where it can (AFK); otherwise it hands the human a precise checklist (HITL). Resolved when the work is done; the answer records what was done and any resulting facts (credentials location, new URLs, row counts) later tickets depend on.
 
 ## Fog of war
 

--- a/skills/productivity/grilling/SKILL.md
+++ b/skills/productivity/grilling/SKILL.md
@@ -7,6 +7,6 @@ Interview me relentlessly about every aspect of this plan until we reach a share
 
 Ask the questions one at a time, waiting for feedback on each question before continuing. Asking multiple questions at once is bewildering.
 
-If a question can be answered by exploring the codebase, explore the codebase instead.
+If a *fact* can be found by exploring the codebase, look it up rather than asking me. The *decisions*, though, are mine — put each one to me and wait for my answer.
 
 Do not enact the plan until I confirm we have reached a shared understanding.


### PR DESCRIPTION
## Problem

Students reported `/wayfinder` picking a **grilling** ticket and grilling *itself* instead of turning to the human — confirmed in the community by @_noshit and @maudova, and Matt's response: *"that sounds like a bug to me."*

**Root cause** — a branch collision that triggers premature completion:

- `grilling` has a line built for the live-human case: *"If a question can be answered by exploring the codebase, explore the codebase instead."*
- When `wayfinder` runs `grilling` inside a **resolve-the-ticket** frame, the agent reads "explore instead [of asking]" as license to **answer questions itself** and races the ticket to "resolved" — playing both interviewer and interviewee.

## Fix

Three small edits, all **affirmative** framing (no negative-space "don't do X", which tends to backfire):

1. **`grilling`** — split *facts* (look them up) from *decisions* ("put each one to me and wait for my answer").
2. **`wayfinder` Grilling ticket type** — reframed from the ambiguous "Conversation with the agent" to "A live back-and-forth with the **human** … the human answering each."
3. **`wayfinder` Invocation** — a standing rule beside the existing one: "grilling always runs with the **human**."

The correction lands by describing the human's role (they answer each question) rather than forbidding the failure.