### PR TITLE
fix(wayfinder): resolve issue-tracker doc via the CLAUDE.md pointer, not a hardcoded path

### DIFF
--- a/.changeset/wayfinder-tracker-indirection.md
+++ b/.changeset/wayfinder-tracker-indirection.md
@@ -1,0 +1,7 @@
+---
+"mattpocock-skills": patch
+---
+
+Fix **`wayfinder`** hardcoding the issue-tracker doc path, which broke the indirection the rest of the suite relies on.
+
+`to-issues`, `to-prd`, and `triage` never name a path — they resolve the tracker through the `### Issue tracker` block that `setup-matt-pocock-skills` writes into `CLAUDE.md` / `AGENTS.md`, which points at the tracker doc wherever it lives. Wayfinder instead pinned the literal `docs/agents/issue-tracker.md`, so in a repo that keeps its agent docs elsewhere it silently fell back to the local-markdown tracker — even one whose `CLAUDE.md` clearly declares GitHub issues. It now resolves the doc via that same pointer and reads its "Wayfinding operations" section by name, keeping the indirection consistent across the suite.

--- a/skills/in-progress/wayfinder/SKILL.md
+++ b/skills/in-progress/wayfinder/SKILL.md
@@ -21,7 +21,7 @@ The map is a single issue on this repo's issue tracker, labelled `wayfinder:map`
 
 The map is an **index**, not a store. It lists the decisions made and points at the tickets that hold their detail; a decision lives in exactly one place — its ticket — so the map never restates it, only gists it and links.
 
-**Where the map, its child tickets, blocking, and frontier queries physically live is tracker-specific.** Consult `docs/agents/issue-tracker.md` (the "Wayfinding operations" section) for how _this_ repo expresses them. If that doc is absent, default to the local-markdown tracker.
+**Where the map, its child tickets, blocking, and frontier queries physically live is tracker-specific.** The issue tracker should have been provided to you — run `/setup-matt-pocock-skills` if not. Consult the tracker doc's "Wayfinding operations" section for how _this_ repo expresses them. If no tracker has been provided, default to the local-markdown tracker.
 
 ### The map body
 


### PR DESCRIPTION
Closes #471.

## Problem

`wayfinder`'s body hardcodes the literal path `docs/agents/issue-tracker.md` when it needs the tracker's "Wayfinding operations" section:

> Consult `docs/agents/issue-tracker.md` (the "Wayfinding operations" section)…

The rest of the suite (`to-issues`, `to-prd`, `triage`) never names a path. They resolve the tracker through the `### Issue tracker` block that `setup-matt-pocock-skills` writes into `CLAUDE.md` / `AGENTS.md`, which points at the tracker doc *wherever it lives*. That single indirection is exactly what lets a dev keep their agent docs somewhere other than `docs/agents/` (e.g. `agent-docs/`) and still work with every skill.

Because wayfinder pinned the path, in those repos it doesn't find the doc and silently falls back to the local-markdown tracker — even in a repo whose `CLAUDE.md` clearly declares GitHub issues, so it can start writing markdown tickets where `gh` issues are expected.

## Fix

Wayfinder still needs a specific section the others don't (the sub-issue / dependency mechanics), so it keeps referencing **"Wayfinding operations" by name** — but it now resolves *which doc* the same way the rest of the suite does, via the `CLAUDE.md` / `AGENTS.md` pointer, keeping the indirection consistent.

One line in `SKILL.md` plus a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)