### PR TITLE
fix(to-tickets): remove stray </content> tag

### DIFF
--- a/docs/engineering/to-spec.md
+++ b/docs/engineering/to-spec.md
@@ -57,4 +57,3 @@ grill-with-docs → to-spec → to-tickets → implement → code-review
 ```
 
 Reach for it after the plan and domain language are resolved, and before you break the work into implementation tickets. Its key neighbours are [grill-with-docs](https://aihero.dev/skills-grill-with-docs), which sharpens the context so the spec is precise, and [to-tickets](https://aihero.dev/skills-to-tickets), which turns the spec into a set of tickets for [implement](https://aihero.dev/skills-implement) to build. When you're unsure which skill or flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.
-</content>

--- a/docs/engineering/to-tickets.md
+++ b/docs/engineering/to-tickets.md
@@ -54,4 +54,3 @@ grill-with-docs → to-spec → to-tickets → implement → code-review
 ```
 
 It sits between [to-spec](https://aihero.dev/skills-to-spec), which hands it a settled spec with user stories to slice against, and [implement](https://aihero.dev/skills-implement), which builds each ticket, driving [tdd](https://aihero.dev/skills-tdd) internally to write the tests test-first, before its [code-review](https://aihero.dev/skills-code-review) pass. Work the frontier one ticket per fresh context, clearing between them. When you're unsure which skill or flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.
-</content>

--- a/skills/engineering/to-tickets/SKILL.md
+++ b/skills/engineering/to-tickets/SKILL.md
@@ -105,4 +105,3 @@ The end-to-end behaviour this ticket makes work, from the user's perspective —
 In either form, avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
 
 Work the frontier one ticket at a time with `/implement`, clearing context between tickets.
-</content>


### PR DESCRIPTION
## Problem

Fixes #495. The final line of `skills/engineering/to-tickets/SKILL.md` carried a stray `</content>` closing tag with no matching opening tag — a serialization/packaging artifact, not valid Markdown or skill content.

## Fix

While fixing it, `grep` turned up the identical stray tag at the end of two generated landing docs (`docs/engineering/to-tickets.md` and `docs/engineering/to-spec.md`), both introduced by the same planning-skills refactor (386d4ff). No other SKILL.md or doc was affected, so this is an accidental paste rather than a systematic generation bug. Stripped the tag from all three files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)