### PR TITLE
fix(to-tickets): publish one local file per ticket, not a single tickets.md

### DIFF
--- a/.changeset/to-tickets-local-per-file.md
+++ b/.changeset/to-tickets-local-per-file.md
@@ -1,0 +1,5 @@
+---
+"mattpocock-skills": patch
+---
+
+Fix `to-tickets` collapsing every local ticket into a single root `tickets.md`. On a local-markdown tracker it now publishes **one file per ticket** under the configured local structure (`.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered in dependency order, each with a `Status:` line and text "Blocked by" references), matching the local issue-tracker model that `triage`, `wayfinder`, and the rest of the engineering skills already use. Real trackers are unchanged — still one issue per ticket with native blocking links. The single-file `tickets.md` template is gone; local and real trackers now share one per-ticket template, differing only in where the ticket lands and how its blocking edges are expressed.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Skills I use daily for code work.
 - **[improve-codebase-architecture](./skills/engineering/improve-codebase-architecture/SKILL.md)** — Scan a codebase for deepening opportunities, present them as a visual HTML report, then grill through whichever one you pick.
 - **[setup-matt-pocock-skills](./skills/engineering/setup-matt-pocock-skills/SKILL.md)** — Configure this repo for the engineering skills (issue tracker, triage labels, domain doc layout). Run once per repo before using the other engineering skills.
 - **[to-spec](./skills/engineering/to-spec/SKILL.md)** — Turn the current conversation into a spec and publish it to the issue tracker. No interview — just synthesizes what you've already discussed.
-- **[to-tickets](./skills/engineering/to-tickets/SKILL.md)** — Break any plan, spec, or conversation into a set of tracer-bullet tickets, each declaring its blocking edges — written as text in a local file, or as native blocking links on a real tracker.
+- **[to-tickets](./skills/engineering/to-tickets/SKILL.md)** — Break any plan, spec, or conversation into a set of tracer-bullet tickets, each declaring its blocking edges — one local file per ticket with edges as text, or one issue per ticket with native blocking links on a real tracker.
 - **[implement](./skills/engineering/implement/SKILL.md)** — Build the work described by a spec or set of tickets, driving `/tdd` at pre-agreed seams and closing out with `/code-review` before committing.
 - **[wayfinder](./skills/engineering/wayfinder/SKILL.md)** — Plan a huge chunk of work, more than one agent session can hold, as a shared map of investigation tickets on the issue tracker — resolve them one at a time until the way to the destination is clear.
 

--- a/docs/engineering/to-tickets.md
+++ b/docs/engineering/to-tickets.md
@@ -28,9 +28,9 @@ Reach for it once you have an agreed plan or a written spec and you want it spli
 
 ## One artifact, two readings
 
-The blocking edges are the whole point. They make one set of tickets read two ways, depending on the tracker:
+The blocking edges are the whole point. Either way you get **one file or issue per ticket** — never all of them collapsed into one document — and the edges make the set read two ways, depending on the tracker:
 
-- **Local files** → a single `tickets.md` in the repo root, the edges written as text. You work it top-to-bottom, by hand, staying in the loop.
+- **Local files** → one file per ticket under `.scratch/<feature>/issues/`, the edges written as text. You work the frontier top-to-bottom, by hand, staying in the loop.
 - **A real tracker (GitHub, Linear)** → one issue per ticket, the edges as native blocking links (or sub-issues). Any ticket whose blockers are all done is on the **frontier** and can be grabbed — so several agents can run at once.
 
 The edges live in the ticket regardless of medium; the medium only decides whether anything acts on them in parallel. `to-tickets` produces the artifact — how you run it (sequential by hand, or a parallel fleet) is up to you.

--- a/skills/engineering/README.md
+++ b/skills/engineering/README.md
@@ -12,7 +12,7 @@ Reachable only when you type them (`disable-model-invocation: true`).
 - **[improve-codebase-architecture](./improve-codebase-architecture/SKILL.md)** — Scan a codebase for deepening opportunities, present them as a visual HTML report, then grill through whichever one you pick.
 - **[setup-matt-pocock-skills](./setup-matt-pocock-skills/SKILL.md)** — Configure this repo for the engineering skills (issue tracker, triage labels, domain doc layout). Run once per repo.
 - **[to-spec](./to-spec/SKILL.md)** — Turn the current conversation into a spec and publish it to the issue tracker.
-- **[to-tickets](./to-tickets/SKILL.md)** — Break any plan, spec, or conversation into a set of tracer-bullet tickets, each declaring its blocking edges — text in a local file, or native blocking links on a real tracker.
+- **[to-tickets](./to-tickets/SKILL.md)** — Break any plan, spec, or conversation into a set of tracer-bullet tickets, each declaring its blocking edges — one local file per ticket with edges as text, or one issue per ticket with native blocking links on a real tracker.
 - **[wayfinder](./wayfinder/SKILL.md)** — Plan a huge chunk of work — more than one agent session can hold — as a shared map of investigation tickets on the issue tracker, resolved one at a time until the way to the destination is clear.
 
 ## Model-invoked

--- a/skills/engineering/ask-matt/SKILL.md
+++ b/skills/engineering/ask-matt/SKILL.md
@@ -20,7 +20,7 @@ The route most work travels. You have an idea and want it built.
    - **`/prototype`** to answer the question with throwaway code,
    - **`/handoff`** back what you learned, and reference it from the original idea thread.
 3. **Branch — is this a multi-session build?**
-   - **Yes** → **`/to-spec`** (turn the thread into a spec), then **`/to-tickets`** to split it into tracer-bullet tickets, each declaring its **blocking edges**. On a local tracker that's an ordered `tickets.md` you work by hand; on a real tracker the edges become native blocking links, so any ticket whose blockers are done can be grabbed — kick off **`/implement`** per ticket, **clearing context between each one**.
+   - **Yes** → **`/to-spec`** (turn the thread into a spec), then **`/to-tickets`** to split it into tracer-bullet tickets, each declaring its **blocking edges**. On a local tracker that's one ordered file per ticket you work by hand; on a real tracker the edges become native blocking links, so any ticket whose blockers are done can be grabbed — kick off **`/implement`** per ticket, **clearing context between each one**.
    - **No** → **`/implement`** right here, in the same context window.
 
    Either way, **`/implement`** builds each issue by driving **`/tdd`** internally — one red-green slice at a time — then closes out by running **`/code-review`**, a two-axis review (Standards + Spec) of the diff, before committing. Reach for **`/tdd`** on its own when you just want to build a concrete behaviour test-first without a full spec, and **`/code-review`** on its own whenever you want to review a branch or PR against a fixed point.

--- a/skills/engineering/to-tickets/SKILL.md
+++ b/skills/engineering/to-tickets/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: to-tickets
-description: Break a plan, spec, or the current conversation into a set of tracer-bullet tickets, each declaring its blocking edges, published to the configured tracker — edges as text in a local file, or native blocking links on a real tracker.
+description: Break a plan, spec, or the current conversation into a set of tracer-bullet tickets, each declaring its blocking edges, published one-per-ticket to the configured tracker — one local file per ticket with edges as text, or one issue per ticket with native blocking links on a real tracker.
 disable-model-invocation: true
 ---
 
@@ -57,41 +57,20 @@ Iterate until the user approves the breakdown.
 
 ### 5. Publish the tickets to the configured tracker
 
-Publish the approved tickets. **How** depends on the tracker `/setup-matt-pocock-skills` configured — the tickets are the same either way, only the shape of the blocking edges changes:
+Publish the approved tickets — **one ticket per file or issue**, never all of them collapsed into a single document — in dependency order (blockers first) so each ticket's blocking edges can reference the tickets it depends on. **Where** they go and **how** the edges are expressed depends on the tracker `/setup-matt-pocock-skills` configured; the tickets themselves are the same either way. Follow the conventions in `docs/agents/issue-tracker.md`:
 
-- **Local files** → write one `tickets.md` in the repo root, all tickets in dependency order (blockers first), each with its "Blocked by" listing the titles it depends on. Use the file template below.
-- **A real issue tracker (GitHub, Linear, …)** → publish one issue per ticket in dependency order (blockers first) so each ticket's blocking edges can reference real identifiers. Use the platform's native blocking / sub-issue relationship where it has one; otherwise set each ticket's "Blocked by" to the blocking issues. Apply the `ready-for-agent` triage label unless instructed otherwise — the tickets are agent-grabbable by construction.
+- **Local files** → write one file per ticket under the local tracker's structure (`.scratch/<feature-slug>/issues/<NN>-<slug>.md`, numbered from `01` in dependency order), following `docs/agents/issue-tracker.md`. Record each ticket's triage state as a `Status:` line (`ready-for-agent` unless instructed otherwise — the tickets are agent-grabbable by construction) and set its "Blocked by" to references to the blocking ticket files (e.g. their `NN` numbers). Use the ticket template below.
+- **A real issue tracker (GitHub, Linear, …)** → publish one issue per ticket so each ticket's blocking edges can reference real identifiers. Use the platform's native blocking / sub-issue relationship where it has one; otherwise set each ticket's "Blocked by" to the blocking issues. Apply the `ready-for-agent` triage label unless instructed otherwise — the tickets are agent-grabbable by construction. Use the ticket template below.
+
+Work the **frontier**: any ticket whose blockers are all done. For a purely linear chain that means blockers first, top to bottom.
 
 Do NOT close or modify any parent issue.
 
-<tickets-file-template>
-
-# Tickets: <short name of the work>
-
-A one-line summary of what these tickets build. Reference the source spec if there is one.
-
-Work the **frontier**: any ticket whose blockers are all done. For a purely linear chain that means top to bottom.
-
-## <Ticket title>
-
-**What to build:** the end-to-end behaviour this ticket makes work, from the user's perspective — not a layer-by-layer implementation list.
-
-**Blocked by:** the titles of the tickets that gate this one, or "None — can start immediately".
-
-- [ ] Acceptance criterion 1
-- [ ] Acceptance criterion 2
-
-## <Ticket title>
-
-...
-
-</tickets-file-template>
-
-<issue-template>
+<ticket-template>
 
 ## Parent
 
-A reference to the parent issue on the tracker (if the source was an existing issue, otherwise omit this section).
+A reference to the source spec or parent issue this ticket came from (the `PRD.md` in the same local directory, or the parent issue on a real tracker) — omit this section if there was no source.
 
 ## What to build
 
@@ -106,7 +85,7 @@ The end-to-end behaviour this ticket makes work, from the user's perspective —
 
 - A reference to each blocking ticket, or "None — can start immediately".
 
-</issue-template>
+</ticket-template>
 
 In either form, avoid specific file paths or code snippets — they go stale fast. Exception: if a prototype produced a snippet that encodes a decision more precisely than prose can (state machine, reducer, schema, type shape), inline it and note briefly that it came from a prototype. Trim to the decision-rich parts — not a working demo, just the important bits.
 


### PR DESCRIPTION
Fixes #494.

## Problem

`to-tickets` step 5 told local-markdown users to collapse **every** generated ticket into a single root-level `tickets.md`. That contradicts the local issue-tracker convention the rest of the engineering skills already use — one file per ticket at `.scratch/<feature-slug>/issues/<NN>-<slug>.md` (see `setup-matt-pocock-skills/issue-tracker-local.md`, and how `triage` / `wayfinder` read it). It made locating or grabbing a single ticket awkward and didn't line up with the frontier model.

## Fix (issue's Option 1)

- **`to-tickets/SKILL.md`** — step 5 now publishes **one file per ticket** locally, under the configured local structure, numbered in dependency order, each with a `Status:` line (`ready-for-agent` by default) and text "Blocked by" references. Removed the single-file `tickets-file-template`; local and real trackers now share **one per-ticket template**, differing only in *where* the ticket lands and *how* its blocking edges are expressed. Frontmatter description updated.
- **`docs/engineering/to-tickets.md`**, **`README.md`**, **`skills/engineering/README.md`**, **`ask-matt/SKILL.md`** — swept the "single local file" wording to "one file per ticket".
- Added a patch changeset.

Real trackers (GitHub/Linear) are unchanged — still one issue per ticket with native blocking links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)