### PR TITLE
fix: finish promoted-bucket wiring for resolving-merge-conflicts and implement

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,6 +17,7 @@
     "./skills/engineering/domain-modeling",
     "./skills/engineering/codebase-design",
     "./skills/engineering/code-review",
+    "./skills/engineering/resolving-merge-conflicts",
     "./skills/productivity/grill-me",
     "./skills/productivity/grilling",
     "./skills/productivity/handoff",

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Skills I use daily for code work.
 - **[domain-modeling](./skills/engineering/domain-modeling/SKILL.md)** — Actively build and sharpen a project's domain model — challenge terms against the glossary, stress-test with edge-case scenarios, and update `CONTEXT.md` and ADRs inline.
 - **[codebase-design](./skills/engineering/codebase-design/SKILL.md)** — Shared discipline and vocabulary for designing deep modules: a lot of behaviour behind a small interface, placed at a clean seam, testable through that interface.
 - **[code-review](./skills/engineering/code-review/SKILL.md)** — Two-axis review of the diff since a fixed point: **Standards** (does it follow the repo's coding standards, plus a Fowler smell baseline?) and **Spec** (does it faithfully implement the originating issue/PRD?), run as parallel sub-agents so neither pollutes the other.
+- **[resolving-merge-conflicts](./skills/engineering/resolving-merge-conflicts/SKILL.md)** — Work through an in-progress git merge or rebase conflict hunk by hunk, resolving by intent traced to each side's primary source, then finish the operation — never `--abort`.
 
 ### Productivity
 

--- a/skills/engineering/README.md
+++ b/skills/engineering/README.md
@@ -13,6 +13,7 @@ Reachable only when you type them (`disable-model-invocation: true`).
 - **[setup-matt-pocock-skills](./setup-matt-pocock-skills/SKILL.md)** — Configure this repo for the engineering skills (issue tracker, triage labels, domain doc layout). Run once per repo.
 - **[to-spec](./to-spec/SKILL.md)** — Turn the current conversation into a spec and publish it to the issue tracker.
 - **[to-tickets](./to-tickets/SKILL.md)** — Break any plan, spec, or conversation into a set of tracer-bullet tickets, each declaring its blocking edges — text in a local file, or native blocking links on a real tracker.
+- **[implement](./implement/SKILL.md)** — Build the work described by a spec or set of tickets, driving `/tdd` at pre-agreed seams and closing out with `/code-review` before committing.
 - **[wayfinder](./wayfinder/SKILL.md)** — Plan a huge chunk of work — more than one agent session can hold — as a shared map of decision tickets on the issue tracker, resolved one at a time until the way to the destination is clear.
 
 ## Model-invoked
@@ -27,3 +28,4 @@ Model- or user-reachable (rich trigger phrasing so the model can reach for them)
 - **[domain-modeling](./domain-modeling/SKILL.md)** — Actively build and sharpen a project's domain model — challenge terms, stress-test with scenarios, update `CONTEXT.md` and ADRs inline.
 - **[codebase-design](./codebase-design/SKILL.md)** — Shared discipline and vocabulary for designing deep modules: small interfaces, clean seams, testable through the interface.
 - **[code-review](./code-review/SKILL.md)** — Two-axis review of the diff since a fixed point: **Standards** (does it follow the repo's coding standards, plus a Fowler smell baseline?) and **Spec** (does it faithfully implement the originating issue/PRD?), run as parallel sub-agents.
+- **[resolving-merge-conflicts](./resolving-merge-conflicts/SKILL.md)** — Work through an in-progress git merge or rebase conflict hunk by hunk, resolving by intent traced to each side's primary source, then finish the operation — never `--abort`.


### PR DESCRIPTION
## What & why

Closes a standing `CLAUDE.md`-invariant gap that predates any open PR. The invariant requires every skill in the promoted buckets (`engineering/`, `productivity/`) to appear in `.claude-plugin/plugin.json`, the top-level `README.md`, its bucket `README.md` (grouped by invocation), and to have a docs page. Two skills were only partially wired.

## Changes

- **`resolving-merge-conflicts`** (model-invoked; docs page already existed) — was missing from all three of `.claude-plugin/plugin.json`, the top-level `README.md`, and `skills/engineering/README.md`. Added to all three, under **Model-invoked**.
- **`implement`** (user-invoked, `disable-model-invocation: true`) — already in `plugin.json` and the top `README.md`, but missing from `skills/engineering/README.md`. Added the bucket-README line only, under **User-invoked**.

Descriptions were derived from each skill's own `SKILL.md` / docs page and kept consistent with neighbours.

## Audit

I audited every promoted skill against the 4-point invariant. **No other gaps** — these two were the only ones. Diff is 3 files, 4 insertions.

## Scope

Deliberately **separate from the Codex-metadata work** (rework of PR #522). This PR touches only `plugin.json` and README files — no `agents/openai.yaml`, no Ruby validator, no `package.json`, nothing Codex-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)