### PR TITLE
feat: add Codex agents/openai.yaml metadata to every skill

### DIFF
--- a/.agents/invocation.md
+++ b/.agents/invocation.md
@@ -2,10 +2,12 @@
 
 Every `SKILL.md` in this repo is a skill. The one axis that splits them is **invocation** — who can reach it:
 
-- **User-invoked** — reachable **only by the human typing its name**. Set `disable-model-invocation: true` in the frontmatter. The `description` is **human-facing**: a one-line summary read by a person browsing slash-commands. Strip trigger lists ("Use when the user says…").
-- **Model-invoked** — reachable by **model or user**. The default: omit `disable-model-invocation`. The `description` is **model-facing** and keeps rich trigger phrasing ("Use when the user wants…, mentions…, asks for…") so auto-invocation fires. The test for whether a skill should stay model-invoked: _could the model usefully reach for this autonomously?_ (Reuse is the reason to extract a skill, not the test.)
+- **User-invoked** — reachable **only by the human typing its name**. Set `disable-model-invocation: true` in the frontmatter (Claude Code) and `policy.allow_implicit_invocation: false` in `agents/openai.yaml` (Codex). The `description` is **human-facing**: a one-line summary read by a person browsing slash-commands. Strip trigger lists ("Use when the user says…").
+- **Model-invoked** — reachable by **model or user**. The default: omit `disable-model-invocation` and the `policy` block from `agents/openai.yaml`. The `description` is **model-facing** and keeps rich trigger phrasing ("Use when the user wants…, mentions…, asks for…") so auto-invocation fires. The test for whether a skill should stay model-invoked: _could the model usefully reach for this autonomously?_ (Reuse is the reason to extract a skill, not the test.)
 
-Because a user-invoked skill has no description, nothing but the human can reach it — no other skill can fire it. So a user-invoked skill may invoke model-invoked skills, but it can never reach another user-invoked skill.
+Each harness excludes a user-invoked skill from the model's reach in its own way, so nothing but the human can fire it — no other skill can. A user-invoked skill may invoke model-invoked skills, but it can never reach another user-invoked skill.
+
+Every skill also carries an `agents/openai.yaml` beside its `SKILL.md`. It holds Codex UI metadata — `interface.display_name` and `interface.short_description` for the skill picker — and, for user-invoked skills, the `policy.allow_implicit_invocation: false` that pairs with `disable-model-invocation`. Keep the two in sync: a skill is user-invoked in both harnesses or neither.
 
 Bucket `README.md`s and the top-level `README.md` group entries into **User-invoked** and **Model-invoked**.
 

--- a/.changeset/codex-skill-metadata.md
+++ b/.changeset/codex-skill-metadata.md
@@ -1,0 +1,10 @@
+---
+"mattpocock-skills": minor
+---
+
+Add Codex metadata alongside each skill's Claude Code frontmatter so the set works in both harnesses without generated copies.
+
+- Add an `agents/openai.yaml` beside every `SKILL.md` with Codex UI metadata (`interface.display_name`, `interface.short_description`).
+- Mark every user-invoked skill with `policy.allow_implicit_invocation: false`, the Codex analog of `disable-model-invocation: true`, so Codex excludes it from implicit invocation while explicit `$skill` invocation still works.
+- Document the dual-harness invocation model in `.agents/invocation.md`, `CLAUDE.md`, and the promoted-bucket READMEs.
+- Add `AGENTS.md` as a symlink to `CLAUDE.md` so Codex reads the same repo instructions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Each bucket folder has a `README.md` that lists every skill in the bucket with a
 
 Skills in `engineering/` and `productivity/` also have a human-facing docs page at `docs/<bucket>/<skill-name>.md` (the docs tree mirrors those two bucket folders under `skills/`). The published URL is `https://aihero.dev/skills-<skill-name>` regardless of bucket — the docs path is repo organisation only. When you add, rename, or change the behaviour of a skill in `engineering/` or `productivity/`, create or re-sync its docs page following [.agents/writing-docs.md](./.agents/writing-docs.md). Skills in the non-promoted buckets (`misc/`, `personal/`, `in-progress/`, `deprecated/`) get **no** docs page.
 
-Every `SKILL.md` is either user-invoked (`disable-model-invocation: true`, reachable only by the human) or model-invoked (model- or user-reachable). See [.agents/invocation.md](./.agents/invocation.md).
+Every `SKILL.md` is either user-invoked (`disable-model-invocation: true` plus `policy.allow_implicit_invocation: false` in `agents/openai.yaml`, reachable only by the human) or model-invoked (model- or user-reachable). See [.agents/invocation.md](./.agents/invocation.md).
 
 [`ask-matt`](./skills/engineering/ask-matt/SKILL.md) is the router that maps every user-reachable skill and how they relate. The same trigger that re-syncs a docs page applies to it: whenever you add, rename, remove, or change how a user-reachable skill fits the flows, re-read `ask-matt`'s `SKILL.md` and update it so the map stays accurate — a new skill it never mentions, or a stale one it still routes to, is a router that lies.
 

--- a/scripts/link-skills.sh
+++ b/scripts/link-skills.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 # Links all skills in the repository into the local skill directories used by
 # each agent harness:
 #   - ~/.claude/skills  — Claude Code
-#   - ~/.agents/skills  — pi and other Agent-Skills-standard harnesses
+#   - ~/.agents/skills  — Codex and other Agent Skills-compatible harnesses
 # Each entry is a symlink into this repo, so a `git pull` is all that's needed
 # to keep installed skills up to date.
 

--- a/skills/deprecated/design-an-interface/agents/openai.yaml
+++ b/skills/deprecated/design-an-interface/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Design an Interface"
+  short_description: "Explore alternative module interfaces"

--- a/skills/deprecated/qa/agents/openai.yaml
+++ b/skills/deprecated/qa/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "QA"
+  short_description: "Conversational QA that files issues"

--- a/skills/deprecated/request-refactor-plan/agents/openai.yaml
+++ b/skills/deprecated/request-refactor-plan/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Request Refactor Plan"
+  short_description: "Plan a safe incremental refactor"

--- a/skills/deprecated/ubiquitous-language/agents/openai.yaml
+++ b/skills/deprecated/ubiquitous-language/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Ubiquitous Language"
+  short_description: "Build a shared domain glossary"
+policy:
+  allow_implicit_invocation: false

--- a/skills/engineering/README.md
+++ b/skills/engineering/README.md
@@ -4,7 +4,7 @@ Skills I use daily for code work.
 
 ## User-invoked
 
-Reachable only when you type them (`disable-model-invocation: true`).
+Reachable only when you type them (Claude Code: `disable-model-invocation: true`; Codex: `policy.allow_implicit_invocation: false` in `agents/openai.yaml`).
 
 - **[ask-matt](./ask-matt/SKILL.md)** — Ask which skill or flow fits your situation. A router over the user-invoked skills in this repo.
 - **[grill-with-docs](./grill-with-docs/SKILL.md)** — Grilling session that also builds your project's domain model, sharpening terminology and updating `CONTEXT.md` and ADRs inline.

--- a/skills/engineering/ask-matt/agents/openai.yaml
+++ b/skills/engineering/ask-matt/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Ask Matt"
+  short_description: "Find the right skill or workflow"
+policy:
+  allow_implicit_invocation: false

--- a/skills/engineering/code-review/agents/openai.yaml
+++ b/skills/engineering/code-review/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Code Review"
+  short_description: "Review a diff on standards and spec"

--- a/skills/engineering/codebase-design/agents/openai.yaml
+++ b/skills/engineering/codebase-design/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Codebase Design"
+  short_description: "Vocabulary for deep-module design"

--- a/skills/engineering/diagnosing-bugs/agents/openai.yaml
+++ b/skills/engineering/diagnosing-bugs/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Diagnosing Bugs"
+  short_description: "Diagnose hard bugs and regressions"

--- a/skills/engineering/domain-modeling/agents/openai.yaml
+++ b/skills/engineering/domain-modeling/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Domain Modeling"
+  short_description: "Build and sharpen a domain model"

--- a/skills/engineering/grill-with-docs/agents/openai.yaml
+++ b/skills/engineering/grill-with-docs/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Grill with Docs"
+  short_description: "Grill a design and write its docs"
+policy:
+  allow_implicit_invocation: false

--- a/skills/engineering/implement/agents/openai.yaml
+++ b/skills/engineering/implement/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Implement"
+  short_description: "Build work from a spec or tickets"
+policy:
+  allow_implicit_invocation: false

--- a/skills/engineering/improve-codebase-architecture/agents/openai.yaml
+++ b/skills/engineering/improve-codebase-architecture/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Improve Codebase Architecture"
+  short_description: "Find and grill architecture improvements"
+policy:
+  allow_implicit_invocation: false

--- a/skills/engineering/prototype/agents/openai.yaml
+++ b/skills/engineering/prototype/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Prototype"
+  short_description: "Prototype to answer a design question"

--- a/skills/engineering/research/agents/openai.yaml
+++ b/skills/engineering/research/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Research"
+  short_description: "Research from high-trust sources"

--- a/skills/engineering/resolving-merge-conflicts/agents/openai.yaml
+++ b/skills/engineering/resolving-merge-conflicts/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Resolving Merge Conflicts"
+  short_description: "Resolve merge and rebase conflicts"

--- a/skills/engineering/setup-matt-pocock-skills/agents/openai.yaml
+++ b/skills/engineering/setup-matt-pocock-skills/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Setup Matt Pocock Skills"
+  short_description: "Configure a repo for the skills"
+policy:
+  allow_implicit_invocation: false

--- a/skills/engineering/tdd/agents/openai.yaml
+++ b/skills/engineering/tdd/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "TDD"
+  short_description: "Test-driven red-green-refactor"

--- a/skills/engineering/to-spec/agents/openai.yaml
+++ b/skills/engineering/to-spec/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "To Spec"
+  short_description: "Turn a conversation into a spec"
+policy:
+  allow_implicit_invocation: false

--- a/skills/engineering/to-tickets/agents/openai.yaml
+++ b/skills/engineering/to-tickets/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "To Tickets"
+  short_description: "Split a plan into tracer-bullet tickets"
+policy:
+  allow_implicit_invocation: false

--- a/skills/engineering/triage/agents/openai.yaml
+++ b/skills/engineering/triage/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Triage"
+  short_description: "Move issues through triage roles"
+policy:
+  allow_implicit_invocation: false

--- a/skills/engineering/wayfinder/agents/openai.yaml
+++ b/skills/engineering/wayfinder/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Wayfinder"
+  short_description: "Map a large effort as decision tickets"
+policy:
+  allow_implicit_invocation: false

--- a/skills/in-progress/claude-handoff/agents/openai.yaml
+++ b/skills/in-progress/claude-handoff/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Claude Handoff"
+  short_description: "Hand off to a background agent"
+policy:
+  allow_implicit_invocation: false

--- a/skills/in-progress/loop-me/agents/openai.yaml
+++ b/skills/in-progress/loop-me/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Loop Me"
+  short_description: "Spec the workflows you want to build"
+policy:
+  allow_implicit_invocation: false

--- a/skills/in-progress/setup-ts-deep-modules/agents/openai.yaml
+++ b/skills/in-progress/setup-ts-deep-modules/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Setup TS Deep Modules"
+  short_description: "Enforce deep TypeScript modules"
+policy:
+  allow_implicit_invocation: false

--- a/skills/in-progress/wizard/agents/openai.yaml
+++ b/skills/in-progress/wizard/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Wizard"
+  short_description: "Generate an interactive setup wizard"
+policy:
+  allow_implicit_invocation: false

--- a/skills/in-progress/writing-beats/agents/openai.yaml
+++ b/skills/in-progress/writing-beats/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Writing Beats"
+  short_description: "Assemble raw material into beats"
+policy:
+  allow_implicit_invocation: false

--- a/skills/in-progress/writing-fragments/agents/openai.yaml
+++ b/skills/in-progress/writing-fragments/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Writing Fragments"
+  short_description: "Mine raw writing fragments"
+policy:
+  allow_implicit_invocation: false

--- a/skills/in-progress/writing-shape/agents/openai.yaml
+++ b/skills/in-progress/writing-shape/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Writing Shape"
+  short_description: "Shape raw material into an article"
+policy:
+  allow_implicit_invocation: false

--- a/skills/misc/git-guardrails-claude-code/agents/openai.yaml
+++ b/skills/misc/git-guardrails-claude-code/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Git Guardrails for Claude Code"
+  short_description: "Block dangerous git commands"

--- a/skills/misc/migrate-to-shoehorn/agents/openai.yaml
+++ b/skills/misc/migrate-to-shoehorn/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Migrate to Shoehorn"
+  short_description: "Replace test assertions with shoehorn"

--- a/skills/misc/scaffold-exercises/agents/openai.yaml
+++ b/skills/misc/scaffold-exercises/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Scaffold Exercises"
+  short_description: "Scaffold lint-ready course exercises"

--- a/skills/misc/setup-pre-commit/agents/openai.yaml
+++ b/skills/misc/setup-pre-commit/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Setup Pre-Commit"
+  short_description: "Add pre-commit quality checks"

--- a/skills/personal/edit-article/agents/openai.yaml
+++ b/skills/personal/edit-article/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Edit Article"
+  short_description: "Restructure and tighten a draft"
+policy:
+  allow_implicit_invocation: false

--- a/skills/personal/obsidian-vault/agents/openai.yaml
+++ b/skills/personal/obsidian-vault/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Obsidian Vault"
+  short_description: "Manage linked notes in Obsidian"

--- a/skills/productivity/README.md
+++ b/skills/productivity/README.md
@@ -4,7 +4,7 @@ General workflow tools, not code-specific.
 
 ## User-invoked
 
-Reachable only when you type them (`disable-model-invocation: true`).
+Reachable only when you type them (Claude Code: `disable-model-invocation: true`; Codex: `policy.allow_implicit_invocation: false` in `agents/openai.yaml`).
 
 - **[grill-me](./grill-me/SKILL.md)** — Get relentlessly interviewed about a plan or design until every branch of the decision tree is resolved.
 - **[handoff](./handoff/SKILL.md)** — Compact the current conversation into a handoff document so another agent can continue the work.

--- a/skills/productivity/grill-me/agents/openai.yaml
+++ b/skills/productivity/grill-me/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Grill Me"
+  short_description: "Sharpen a plan through interview"
+policy:
+  allow_implicit_invocation: false

--- a/skills/productivity/grilling/agents/openai.yaml
+++ b/skills/productivity/grilling/agents/openai.yaml
@@ -1,0 +1,3 @@
+interface:
+  display_name: "Grilling"
+  short_description: "Stress-test thinking one question at a time"

--- a/skills/productivity/handoff/agents/openai.yaml
+++ b/skills/productivity/handoff/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Handoff"
+  short_description: "Compact a conversation into a handoff"
+policy:
+  allow_implicit_invocation: false

--- a/skills/productivity/teach/agents/openai.yaml
+++ b/skills/productivity/teach/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Teach"
+  short_description: "Learn a concept in a guided workspace"
+policy:
+  allow_implicit_invocation: false

--- a/skills/productivity/writing-great-skills/agents/openai.yaml
+++ b/skills/productivity/writing-great-skills/agents/openai.yaml
@@ -1,0 +1,5 @@
+interface:
+  display_name: "Writing Great Skills"
+  short_description: "Principles for predictable skills"
+policy:
+  allow_implicit_invocation: false


### PR DESCRIPTION
## What

Adds an `agents/openai.yaml` beside each `SKILL.md` so the skill set works in **Codex** as well as Claude Code — no generated copies, both harnesses read the tree as-is.

- **`interface.display_name` + `interface.short_description`** for the Codex/ChatGPT skill picker, hand-written for all **39** skills (proper acronyms — `TDD`, `QA`, `TS`, not mechanical title-casing).
- **`policy.allow_implicit_invocation: false`** on the **22 user-invoked** skills — the Codex analog of Claude Code's `disable-model-invocation: true`. Codex then excludes them from implicit/model invocation, while explicit `$skill` invocation still works. This is the crux: **user-invoked skills are excluded from Codex** exactly as they are from Claude.
- Documents the dual-harness invocation model in `.agents/invocation.md`, `CLAUDE.md`, and the promoted-bucket READMEs.
- Adds `AGENTS.md` as a symlink to `CLAUDE.md` so Codex reads the same repo instructions; notes Codex as a `link-skills.sh` install target.

Schema verified against OpenAI's official Codex "Build skills" docs: `interface.{display_name,short_description}` and `policy.allow_implicit_invocation` are real fields; `allow_implicit_invocation: false` means *"Codex won't implicitly invoke the skill based on user prompt; explicit `$skill` invocation still works."*

## Relationship to #522

This is a deliberately slim rework of the approach prototyped by @gabimoncha in #522 (credited in the commit). It keeps the essential cross-harness metadata and **drops**:

- the Ruby validator (`scripts/validate-skills.rb`) and the `package.json` test/validate wiring — no new Ruby runtime dependency, no tooling to keep in sync;
- the runtime-detector test (referenced a file that didn't exist, so `npm test` failed);
- per-skill `default_prompt`s (optional starter text, the least valuable field);
- the `codex-handoff` README/changeset references to a skill that wasn't included;
- the unrelated `resolving-merge-conflicts` / `implement` promotion (being fixed separately).

## Scope

`agents/openai.yaml` × 39, plus the four small doc/symlink touches above and a changeset. No `plugin.json`, no scripts, no test harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)