### PR TITLE
refactor(plugin): self-maintaining directory form for plugin skills

### DIFF
--- a/.changeset/plugin-skills-directory-form.md
+++ b/.changeset/plugin-skills-directory-form.md
@@ -1,0 +1,5 @@
+---
+"mattpocock-skills": patch
+---
+
+Switch the plugin manifest's `skills` field to self-maintaining directory form. Instead of hand-listing all 22 skill directories, `.claude-plugin/plugin.json` now points at the two promoted buckets (`./skills/engineering`, `./skills/productivity`) and lets Claude Code discover the skills one level down. New promoted skills are picked up automatically, and the manifest can no longer drift out of sync with the tree.

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -19,27 +19,7 @@
     "productivity"
   ],
   "skills": [
-    "./skills/engineering/ask-matt",
-    "./skills/engineering/diagnosing-bugs",
-    "./skills/engineering/grill-with-docs",
-    "./skills/engineering/triage",
-    "./skills/engineering/improve-codebase-architecture",
-    "./skills/engineering/setup-matt-pocock-skills",
-    "./skills/engineering/tdd",
-    "./skills/engineering/to-spec",
-    "./skills/engineering/to-tickets",
-    "./skills/engineering/wayfinder",
-    "./skills/engineering/implement",
-    "./skills/engineering/prototype",
-    "./skills/engineering/research",
-    "./skills/engineering/domain-modeling",
-    "./skills/engineering/codebase-design",
-    "./skills/engineering/code-review",
-    "./skills/engineering/resolving-merge-conflicts",
-    "./skills/productivity/grill-me",
-    "./skills/productivity/grilling",
-    "./skills/productivity/handoff",
-    "./skills/productivity/teach",
-    "./skills/productivity/writing-great-skills"
+    "./skills/engineering",
+    "./skills/productivity"
   ]
 }


### PR DESCRIPTION
## What

Switch `.claude-plugin/plugin.json`'s `skills` field from a hand-listed enumeration of all 22 skill directories to **directory form** — pointing at the two promoted buckets and letting Claude Code discover the skills one level down:

```json
"skills": [
  "./skills/engineering",
  "./skills/productivity"
]
```

## Why

The enumeration had to be edited by hand every time a skill was promoted, and had already drifted once (it left `resolving-merge-conflicts` off). Directory form is self-maintaining: newly promoted skills under those two buckets are picked up automatically, and the manifest can't fall out of sync with the tree.

## Equivalence

Directory form resolves to **exactly the same 22 skills** as the old list — `engineering` (17) and `productivity` (5) — and the non-promoted buckets (`deprecated`, `in-progress`, `misc`, `personal`) stay excluded. `README.md` files in each bucket are ignored (no `SKILL.md`).

`claude plugin validate .` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)