### PR TITLE
batch-grill-me: granular fact-finding, don't block the round

### DIFF
--- a/skills/in-progress/batch-grill-me/SKILL.md
+++ b/skills/in-progress/batch-grill-me/SKILL.md
@@ -4,12 +4,12 @@ description: A relentless interview that asks every frontier question at once, r
 disable-model-invocation: true
 ---
 
-Interview me relentlessly until we reach a shared understanding. Map this as a **design tree**: every decision branches into the decisions that hang off it.
+Interview the user relentlessly until you reach a shared understanding. Map this as a **design tree**: every decision branches into the decisions that hang off it.
 
-Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled — the questions you can ask *now* without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for my answers before the next round.
+Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled — the questions you can ask *now* without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round.
 
-Each round I answer reshapes the tree — settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier and ask the next round. A question whose answer depends on another question still open in this round belongs to a *later* round, not this one.
+Each round the user answers reshapes the tree — settled decisions push the frontier outward and unblock questions that depended on them. Recompute the frontier and ask the next round. A question whose answer depends on another question still open in this round belongs to a *later* round, not this one.
 
-If a *fact* can be found by exploring the environment (filesystem, tools, etc.), look it up rather than asking me. The *decisions* are mine — put each to me and wait.
+Finding *facts* is your job, never the user's. When a frontier question needs a fact from the environment (filesystem, tools, etc.), dispatch a sub-agent to find it — don't ask the user for anything you could look up yourself. Don't block on it: a running exploration is an unsettled prerequisite, so only the questions downstream of it wait for the sub-agent to report — ask the rest of the frontier now. The *decisions* are the user's — put each to them and wait.
 
-The session is done when the frontier is empty: every branch of the design tree visited, nothing left silently assumed. Do not act on it until I confirm we have reached a shared understanding.
+The session is done when the frontier is empty: every branch of the design tree visited, nothing left silently assumed. Do not act on it until the user confirms you have reached a shared understanding.


### PR DESCRIPTION
## What

Fixes a failure mode in `batch-grill-me` where fact-finding could stall the entire next round.

- A frontier question that needs a **fact** now dispatches a sub-agent to find it, rather than being looked up inline.
- A running exploration is treated as an **unsettled prerequisite** — reusing the skill's existing frontier machinery — so only the questions downstream of it wait for the sub-agent. The rest of the frontier is asked immediately.
- Establishes a clean split the agent hangs the skill on: **facts are yours, decisions are the user's.**
- Rephrased throughout in terms of "the user" for consistency (was first person).

🤖 Generated with [Claude Code](https://claude.com/claude-code)