### PR TITLE
docs: split install instructions by audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,49 +22,64 @@ If you want to keep up with changes to these skills, and any new ones I create, 
 
 [Sign Up To The Newsletter](https://www.aihero.dev/s/skills-newsletter)
 
-## Quickstart (30-second setup)
+## Installation (30-second setup)
 
-1. Run the skills.sh installer:
+Two ways in, two philosophies. **The [Claude Code plugin](https://code.claude.com/docs/en/plugins)** installs the whole set as a managed, read-only bundle that updates when I ship — you subscribe rather than fork. **[skills.sh](https://skills.sh/mattpocock/skills)** copies editable skill files into your project, so you can hack on them and make them your own. Pick one — installing both leaves you with every skill twice.
+
+### 1. Get the skills
+
+<details>
+<summary><strong>Claude Code</strong></summary>
+
+```bash
+claude plugins install mattpocock-skills
+```
+
+Or, from inside a session:
+
+```
+/plugin install mattpocock-skills
+```
+
+It's in Claude Code's official marketplace, so there's nothing to add first, and updates arrive automatically.
+
+</details>
+
+<details>
+<summary><strong>Codex, and other agents</strong></summary>
 
 ```bash
 npx skills@latest add mattpocock/skills
 ```
 
-2. Pick the skills you want, and which coding agents you want to install them on. **Make sure you select `/setup-matt-pocock-skills`**.
+Pick the skills you want, and which coding agents to install them on. **The installer lets you choose which skills to take — make sure `setup-matt-pocock-skills` is one of them.**
 
-3. Run `/setup-matt-pocock-skills` in your agent. It will:
-   - Ask you which issue tracker you want to use (GitHub, Linear, or local files)
-   - Ask you what labels you apply to tickets when you triage them (`/triage` uses labels)
-   - Ask you where you want to save any docs we create
+A native Codex plugin is on the roadmap — see [`.agents/adr/0002-ship-as-a-claude-code-plugin.md`](./.agents/adr/0002-ship-as-a-claude-code-plugin.md).
 
-4. Bam - you're ready to go.
+</details>
 
-## Install as a Claude Code plugin
+<details>
+<summary><strong>For tinkerers</strong></summary>
 
-Prefer a plug-and-play install you don't maintain by hand? These skills also ship as a native [Claude Code plugin](https://code.claude.com/docs/en/plugins). Instead of copying editable files into your repo, the plugin installs the whole skill set as a managed bundle that updates when I ship a new version — you subscribe rather than fork.
-
-Inside Claude Code:
-
-```
-/plugin marketplace add mattpocock/skills
-/plugin install mattpocock-skills@mattpocock
-```
-
-Or from your shell:
+Use the same installer, on any agent — including Claude Code:
 
 ```bash
-claude plugin marketplace add mattpocock/skills
-claude plugin install mattpocock-skills@mattpocock
+npx skills@latest add mattpocock/skills
 ```
 
-Then run `/setup-matt-pocock-skills` once per repo, exactly as in the quickstart above.
+It writes the skills into your repo as ordinary files you own and can edit. Nothing updates behind your back; pull my latest changes when you want them with `npx skills update`.
 
-Two ways to install, two philosophies:
+</details>
 
-- **[skills.sh](https://skills.sh/mattpocock/skills)** copies the skills into your project so you can hack on them and make them your own.
-- **The plugin** keeps them as a read-only, always-current bundle you don't edit — best when you just want my set to work and follow along as it evolves.
+### 2. Run `/setup-matt-pocock-skills`
 
-> Using Codex or another agent? The [skills.sh installer](https://skills.sh/mattpocock/skills) already installs these skills into Codex and other Agent-Skills-standard harnesses today. A native Codex plugin is on the roadmap — see [`.agents/adr/0002-ship-as-a-claude-code-plugin.md`](./.agents/adr/0002-ship-as-a-claude-code-plugin.md).
+In your agent, run it once per repo. It will:
+
+- Ask you which issue tracker you want to use (GitHub, Linear, or local files)
+- Ask you what labels you apply to tickets when you triage them (`/triage` uses labels)
+- Ask you where you want to save any docs we create
+
+### 3. Bam - you're ready to go.
 
 ## Why These Skills Exist
 


### PR DESCRIPTION
Reworks the README's install story now that `mattpocock-skills` ships in Claude Code's **official marketplace** — so `claude plugins install mattpocock-skills` works with no `marketplace add` step first.

## What changed

The old `## Quickstart (30-second setup)` (skills.sh) and `## Install as a Claude Code plugin` sections collapse into a single `## Installation (30-second setup)`, structured as:

1. **Get the skills** — three collapsed `<details>` branches, in order:
   - **Claude Code** → `claude plugins install mattpocock-skills`, plus the in-session `/plugin install` form
   - **Codex, and other agents** → `npx skills@latest add mattpocock/skills`, keeping the "make sure you select `setup-matt-pocock-skills`" warning and the Codex-plugin roadmap pointer to ADR 0002
   - **For tinkerers** → same installer, framed around owning editable files, with `npx skills update`
2. **Run `/setup-matt-pocock-skills`** — promoted to a shared step, since every install path needs it (it was previously buried in the skills.sh steps and cross-referenced from the plugin section)
3. **Bam — you're ready to go.**

The "two ways to install, two philosophies" bullets become the section's opening paragraph, now with an explicit warning against installing both.

## Removed

- The two-step `/plugin marketplace add mattpocock/skills` → `/plugin install mattpocock-skills@mattpocock` instructions, superseded by the one-liner.
- The trailing "Using Codex or another agent?" blockquote, now a first-class branch.

## Notes

- Three headings but two philosophies: branches 2 and 3 are the same installer for different audiences, so the opener keeps the count at two rather than inflating it.
- No `--copy` flag in the tinkering branch — the default `skills add` already writes real, editable files (into `.agents/skills/`, symlinked from `.claude/skills`); `--copy` only changes agent-dir linking.
- README-only. ADR 0002 still describes the plugin decision accurately, but predates the official-marketplace listing and could use a follow-up amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)