### PR TITLE
docs: drop the Quickstart block from all 24 pages

### DIFF
--- a/.agents/install-block.md
+++ b/.agents/install-block.md
@@ -36,7 +36,7 @@ Pick the skills you want, and which coding agents to install them on. **The inst
 
 </canonical-block>
 
-…and the single-skill form on a `docs/` page, where the page already names one skill:
+…and the single-skill form wherever one skill is named on its own. Note that **`docs/` pages are not a consumer of this block**: ai-hero renders the install widget above the body, so a page that writes the commands out duplicates it. See [writing-docs.md](./writing-docs.md).
 
 <canonical-block name="skills-sh-one-skill">
 
@@ -50,7 +50,7 @@ npx skills@latest update <name>
 
 </canonical-block>
 
-`skills@latest` is the pinned spelling in all three. The Quickstart template in [writing-docs.md](./writing-docs.md), and the 24 pages under `docs/`, still carry the older bare `npx skills …`; the docs pass brings them into line.
+`skills@latest` is the pinned spelling in all three. The 24 pages under `docs/` used to carry the older bare `npx skills …`; those blocks are now deleted rather than corrected, because the site renders the install commands itself.
 
 ## The two routes are exclusive
 

--- a/.agents/writing-docs.md
+++ b/.agents/writing-docs.md
@@ -12,21 +12,11 @@ There is no H1 — the published page takes its title from the slug.
 
 ## Page structure
 
-Fill the template below. The **fixed frame** (Quickstart block, source link, `## What it does`, `## When to reach for it`, `## Where it fits`) appears on every page. The **adaptable middle** — `## Prerequisites` and the free-form substance sections — carries only what this particular skill earns; delete the rest.
+Fill the template below. The **fixed frame** (source link, `## What it does`, `## When to reach for it`, `## Where it fits`) appears on every page. The **adaptable middle** — `## Prerequisites` and the free-form substance sections — carries only what this particular skill earns; delete the rest.
 
-Install commands are not written per page. Copy them verbatim from [the canonical install block](./install-block.md) — it is the single source for how anyone installs these skills, and a page that words it differently is a page that tells a second story. The Quickstart block in the template below is the older wording and does not yet match; the docs pass replaces it from the canonical block.
+**A page carries no install commands.** The ai-hero page template renders the install widget itself — a copy button, the single-skill command, the whole-set command, and the update line — above the body. A page that also writes them out shows the reader the same command twice, and the two copies drift: the hand-written pair on all 24 pages went stale against the widget beside it. Install wording is a property of the site, not of the page. If it needs changing, change it in ai-hero; the canonical wording lives in [the install block](./install-block.md).
 
 <page-template>
-
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=<name>
-```
-
-```bash
-npx skills update <name>
-```
 
 [Source](https://github.com/mattpocock/skills/tree/main/skills/<bucket>/<name>)
 
@@ -74,7 +64,7 @@ Always present. Situate the skill in the system in a sentence or two:
 ## Done when
 
 - The page exists at `docs/<bucket>/<name>.md`, and no stale page survives a rename or bucket move.
-- The Quickstart block and source link name the correct bucket and skill; the update line names the skill.
+- The source link names the correct bucket and skill, and the page writes no install command of its own.
 - `## What it does` states the defining constraint, as plain prose rather than a labelled aside.
 - `## When to reach for it` states invocation mode and the trigger boundary.
 - `## Where it fits` names the role and links to `ask-matt`.

--- a/.changeset/docs-drop-quickstart.md
+++ b/.changeset/docs-drop-quickstart.md
@@ -1,0 +1,11 @@
+---
+"mattpocock-skills": patch
+---
+
+Drop the hand-written Quickstart block from all 24 docs pages.
+
+aihero.dev already renders an install widget above every skill page — a copy button, the single-skill command, the whole-set command, and the update line. Each page then wrote the same two commands out again immediately below it. The reader saw the install command twice.
+
+The two copies had also drifted apart. The widget renders the current `npx skills@latest …` wording; the hand-written blocks still carried the older bare `npx skills …`, so every page showed the correct command and a stale one, one after the other.
+
+Deleting the block removes 24 stale copies and leaves the site's own. `.agents/writing-docs.md` now states the rule directly — install wording is a property of the site, not of the page — and its template no longer carries a Quickstart to copy.

--- a/docs/engineering/ask-matt.md
+++ b/docs/engineering/ask-matt.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=ask-matt
-```
-
-```bash
-npx skills update ask-matt
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/ask-matt)
 
 ## What it does

--- a/docs/engineering/code-review.md
+++ b/docs/engineering/code-review.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=code-review
-```
-
-```bash
-npx skills update code-review
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/code-review)
 
 ## What it does

--- a/docs/engineering/codebase-design.md
+++ b/docs/engineering/codebase-design.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=codebase-design
-```
-
-```bash
-npx skills update codebase-design
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/codebase-design)
 
 ## What it does

--- a/docs/engineering/diagnosing-bugs.md
+++ b/docs/engineering/diagnosing-bugs.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=diagnosing-bugs
-```
-
-```bash
-npx skills update diagnosing-bugs
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/diagnosing-bugs)
 
 ## What it does

--- a/docs/engineering/domain-modeling.md
+++ b/docs/engineering/domain-modeling.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=domain-modeling
-```
-
-```bash
-npx skills update domain-modeling
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/domain-modeling)
 
 ## What it does

--- a/docs/engineering/grill-with-docs.md
+++ b/docs/engineering/grill-with-docs.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=grill-with-docs
-```
-
-```bash
-npx skills update grill-with-docs
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/grill-with-docs)
 
 ## What it does

--- a/docs/engineering/implement.md
+++ b/docs/engineering/implement.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=implement
-```
-
-```bash
-npx skills update implement
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/implement)
 
 ## What it does

--- a/docs/engineering/improve-codebase-architecture.md
+++ b/docs/engineering/improve-codebase-architecture.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=improve-codebase-architecture
-```
-
-```bash
-npx skills update improve-codebase-architecture
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/improve-codebase-architecture)
 
 ## What it does

--- a/docs/engineering/prototype.md
+++ b/docs/engineering/prototype.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=prototype
-```
-
-```bash
-npx skills update prototype
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/prototype)
 
 ## What it does

--- a/docs/engineering/research.md
+++ b/docs/engineering/research.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=research
-```
-
-```bash
-npx skills update research
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/research)
 
 ## What it does

--- a/docs/engineering/resolving-merge-conflicts.md
+++ b/docs/engineering/resolving-merge-conflicts.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=resolving-merge-conflicts
-```
-
-```bash
-npx skills update resolving-merge-conflicts
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/resolving-merge-conflicts)
 
 ## What it does

--- a/docs/engineering/setup-matt-pocock-skills.md
+++ b/docs/engineering/setup-matt-pocock-skills.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=setup-matt-pocock-skills
-```
-
-```bash
-npx skills update setup-matt-pocock-skills
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/setup-matt-pocock-skills)
 
 ## What it does

--- a/docs/engineering/tdd.md
+++ b/docs/engineering/tdd.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=tdd
-```
-
-```bash
-npx skills update tdd
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/tdd)
 
 ## What it does

--- a/docs/engineering/to-spec.md
+++ b/docs/engineering/to-spec.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=to-spec
-```
-
-```bash
-npx skills update to-spec
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/to-spec)
 
 ## What it does

--- a/docs/engineering/to-tickets.md
+++ b/docs/engineering/to-tickets.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=to-tickets
-```
-
-```bash
-npx skills update to-tickets
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/to-tickets)
 
 ## What it does

--- a/docs/engineering/triage.md
+++ b/docs/engineering/triage.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=triage
-```
-
-```bash
-npx skills update triage
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/triage)
 
 ## What it does

--- a/docs/engineering/wayfinder.md
+++ b/docs/engineering/wayfinder.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=wayfinder
-```
-
-```bash
-npx skills update wayfinder
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/wayfinder)
 
 ## What it does

--- a/docs/engineering/wizard.md
+++ b/docs/engineering/wizard.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=wizard
-```
-
-```bash
-npx skills update wizard
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/engineering/wizard)
 
 ## What it does

--- a/docs/productivity/grill-me.md
+++ b/docs/productivity/grill-me.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=grill-me
-```
-
-```bash
-npx skills update grill-me
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/productivity/grill-me)
 
 ## What it does

--- a/docs/productivity/grilling.md
+++ b/docs/productivity/grilling.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=grilling
-```
-
-```bash
-npx skills update grilling
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/productivity/grilling)
 
 ## What it does

--- a/docs/productivity/handoff.md
+++ b/docs/productivity/handoff.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=handoff
-```
-
-```bash
-npx skills update handoff
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/productivity/handoff)
 
 ## What it does

--- a/docs/productivity/teach.md
+++ b/docs/productivity/teach.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=teach
-```
-
-```bash
-npx skills update teach
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/productivity/teach)
 
 ## What it does

--- a/docs/productivity/to-questionnaire.md
+++ b/docs/productivity/to-questionnaire.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=to-questionnaire
-```
-
-```bash
-npx skills update to-questionnaire
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/productivity/to-questionnaire)
 
 ## What it does

--- a/docs/productivity/writing-for-agents.md
+++ b/docs/productivity/writing-for-agents.md
@@ -1,13 +1,3 @@
-Quickstart:
-
-```bash
-npx skills add mattpocock/skills --skill=writing-for-agents
-```
-
-```bash
-npx skills update writing-for-agents
-```
-
 [Source](https://github.com/mattpocock/skills/tree/main/skills/productivity/writing-for-agents)
 
 ## What it does


### PR DESCRIPTION
aihero.dev already renders an install widget above every skill page — a copy button, the single-skill command, the whole-set command, and the update line. Each page then wrote the same two commands out again in its body, immediately below it.

The two copies had also drifted apart. The widget renders the current `npx skills@latest …` wording; the hand-written blocks still carried the older bare `npx skills …`. So every page showed the correct command and a stale one, one after the other.

## What changed

- Deleted the Quickstart block from all 24 pages under `docs/`. `[Source]` is now line 1. Zero `npx skills` occurrences remain in `docs/`.
- `.agents/writing-docs.md` — Quickstart removed from the fixed frame and from the page template, with the rule stated directly: install wording is a property of the site, not of the page.
- `.agents/install-block.md` — notes that `docs/` pages are no longer a consumer of the block, and drops the now-obsolete "the docs pass brings them into line" line.
- Changeset added.

## Checks

- All 24 pages had a byte-identical 10-line header before the cut, verified before editing.
- No page carried an `npx skills` occurrence outside those 10 lines.
- No `Quickstart` reference survives anywhere in the repo.

Found while working [T2 · Walk the rendered docs site and set the page standards](https://github.com/mattpocock/personal-wiki/issues/251).

🤖 Generated with [Claude Code](https://claude.com/claude-code)