### PR TITLE
docs: rewrite the grill-me page around what people get wrong

### DIFF
--- a/.changeset/docs-grill-me-pass.md
+++ b/.changeset/docs-grill-me-pass.md
@@ -1,0 +1,17 @@
+---
+"mattpocock-skills": patch
+---
+
+Rewrite the `grill-me` docs page around what people actually get wrong.
+
+The old page explained the mechanism — rounds, the frontier, the decision tree — and stopped there. Every recurring question from the last few months went unanswered on it: which of the three grilling skills to reach for, how many questions is normal, what to do when a question can't be answered by talking, and whether to start a fresh session before writing the spec.
+
+The rewrite keeps the mechanism short and spends the page on the judgement calls instead:
+
+- **Sibling routing** is now a three-way list keyed on what you have in front of you — no codebase, a codebase, or too big for one session — rather than a paragraph.
+- **"It's a conversation, not an interview"** names passivity as the main failure mode. A session where you answer "agreed" forty times produces a plan you didn't write and can't defend.
+- **"Grillable and ungrillable"** gives readers the move for a question that talking cannot settle: stop, prototype, come back. This is where long sessions come from.
+- **A "Common questions" section** answers the six highest-volume ones directly, including how to restore one-question-at-a-time and why you should not clear context before `to-spec`.
+- **"It's working if"** added, led by the sharpest signal: if you never disagreed, you didn't need the session.
+
+Also drops the "plan mode" ambiguity by saying plainly to leave it off.

--- a/docs/productivity/grill-me.md
+++ b/docs/productivity/grill-me.md
@@ -2,22 +2,71 @@
 
 ## What it does
 
-`grill-me` runs a relentless interview about a plan or design, walking every branch of the decision tree until you and the agent reach a **shared understanding**.
+`grill-me` interviews you about a plan until every decision inside it has been made on purpose rather than by default. It asks in **rounds**: each round is the whole **frontier** — every question whose prerequisites you have already settled — so you are never asked something that hinges on an answer it hasn't heard yet.
 
-It asks in **rounds** and waits. A round is the whole **frontier** — every decision whose prerequisites are already settled — put to you as one numbered list, so you're never asked something that hinges on an answer the agent hasn't heard yet. Where a question can be answered by reading the codebase, it goes and reads rather than asking. Each question comes with the agent's own recommended answer, so you are reacting to a proposal, not staring at a blank prompt.
+It is **stateless**. It writes no files and leaves no workspace behind. The only thing it produces is a sharper plan in your own head.
 
 ## When to reach for it
 
-You invoke this by typing `/grill-me` — the agent won't reach for it on its own.
+You invoke this by typing `/grill-me` — the agent won't reach for it on its own. Start it in a **fresh conversation**, not on top of a plan you already had an agent write.
 
-Reach for it before you build, when a plan feels roughly right but you can sense unresolved decisions hiding in it — the moment you want the soft spots found and forced into the open. If you want that same interrogation to also leave a paper trail of ADRs and a glossary behind, use [grill-with-docs](https://aihero.dev/skills-grill-with-docs) instead. And if the effort is too big to hold in one session and the route to the goal is still foggy — a greenfield project, a huge feature build — start further upstream with [wayfinder](https://aihero.dev/skills-wayfinder), which charts it as a map of decisions first and then merges back into this flow.
+Reach for it when a plan feels roughly right and you suspect it isn't. Which of the three grilling skills you want depends on what is in front of you:
 
-## The decision tree
+- **No codebase yet** — `grill-me`. There is nothing to align against, so there is nothing worth recording.
+- **A codebase** — [grill-with-docs](https://aihero.dev/skills-grill-with-docs). The same interview, but stateful: it keeps what it learns in `CONTEXT.md` and ADRs.
+- **Too big for one session** — [wayfinder](https://aihero.dev/skills-wayfinder). It charts the effort as a map and runs grilling sessions inside it.
 
-The session walks the plan as a tree of decisions, settling a parent decision before the choices that hang off it. Your answers reshape the tree and push the frontier outward, so the next round asks whatever they unblocked. The point is not to reach agreement quickly; it is to make every implicit call explicit, so nothing important is left silently assumed. You come out the other side with a plan whose branches have all been visited.
+Leave plan mode off. Plan mode primes the agent to rush toward producing a plan, which is the opposite of staying in inquiry.
 
-`grill-me` is **stateless**: it writes nothing and leaves no workspace behind. It runs anywhere, and the only artifact is the sharpened understanding in the conversation itself. That is the deliberate contrast with [grill-with-docs](https://aihero.dev/skills-grill-with-docs), which captures the same interview as durable ADRs and a glossary.
+## It's a conversation, not an interview
+
+The skill asks the questions, but **you** own the scope. That is the part people miss, and it separates a session that sharpens a plan from one that produces confident nonsense.
+
+The failure mode is **passivity** — answering "agreed, agreed, agreed" for forty questions and coming out with a plan the agent wrote and you nodded at. It feels productive because it was long. Nothing was actually decided, and the result carries a certainty it hasn't earned.
+
+Being active means steering. Push back on a question pitched beneath the fidelity you need. Say when the scope is drifting. Answer "I don't know" and mean it. This skill is built to aid an engineer, not to replace one: what comes out tracks the quality of your answers, not the number of questions asked.
+
+The opposite error is real but rarer — staying in the interview so long you never reach code.
+
+## Grillable and ungrillable
+
+Some questions can be answered by talking. Others can't, and no amount of grilling will get you there.
+
+"One long form or three pages?" and "how should this interaction feel?" are **ungrillable** — they need something to react to. When you hit one, stop grilling. Build the throwaway version with [prototype](https://aihero.dev/skills-prototype), look at it, then come back and answer in one line.
+
+Talking your way through an ungrillable question is where sessions balloon. The agent keeps rephrasing, you keep guessing, and the scope grows to fill the uncertainty.
+
+## It's working if
+
+- You disagree with something. A session with no pushback from you is a session you didn't need.
+- Questions arrive in a few rounds rather than one long drip, and later rounds clearly build on what you said earlier.
+- You end up somewhere you didn't expect, because a question surfaced a decision you had been making implicitly.
+- At the end you could defend each choice to someone who wasn't there.
+
+## Common questions
+
+**How many questions should I expect, and how do I know when it ends?**
+Count rounds, not questions. Forty-six questions across four rounds is an ordinary session. It ends when the frontier is empty — every branch visited, nothing left silently assumed.
+
+**It asked me two hundred questions. What went wrong?**
+Usually the scope was too large. Ask the agent to break the work into smaller pieces first, then grill each one. Very long sessions also drift into the **dumb zone**, where the context window is full enough that the questions get worse.
+
+**Can I go back to one question at a time?**
+Yes. Add this to your global `CLAUDE.md`:
+
+```
+When grilling, ask one question at a time.
+```
+
+**What if I genuinely don't know the answer?**
+Say so. "I don't know" is a real answer, and a question you can't answer is usually a sign to prototype rather than to guess.
+
+**Do I start a fresh session before writing the spec?**
+No. The value of the session is the context you just built. Hand the same conversation straight to [to-spec](https://aihero.dev/skills-to-spec).
+
+**Does the model matter?**
+More than for most skills. Grilling leans on the model's own sense of how systems break, so give it your best one. Implementation mostly follows context and tolerates a cheaper model.
 
 ## Where it fits
 
-`grill-me` is a reach-for-it-anytime standalone — the pre-build stress test you run whenever a plan needs hardening. It is the stateless, user-invoked front door to the [grilling](https://aihero.dev/skills-grilling) primitive; its closest neighbour is [grill-with-docs](https://aihero.dev/skills-grill-with-docs), the stateful sibling that runs the same interview but additionally records the decisions as ADRs and a glossary. If the outcome is a spec you want written down, hand off to [to-spec](https://aihero.dev/skills-to-spec), which synthesises the settled understanding into a spec without re-interviewing you. When you're unsure which flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.
+`grill-me` is a reach-for-it-anytime standalone — the pre-build stress test you run whenever a plan needs hardening. It is the stateless, user-invoked front door to the [grilling](https://aihero.dev/skills-grilling) primitive; its closest neighbour is [grill-with-docs](https://aihero.dev/skills-grill-with-docs), the stateful sibling that runs the same interview against a codebase and records the decisions as ADRs and a glossary. When the plan is settled, hand the conversation to [to-spec](https://aihero.dev/skills-to-spec), which writes it up without re-interviewing you. When you're unsure which flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.

--- a/docs/productivity/grill-me.md
+++ b/docs/productivity/grill-me.md
@@ -2,25 +2,27 @@
 
 ## What it does
 
-`grill-me` interviews you about a plan until every decision inside it has been made on purpose rather than by default. It asks in **rounds**: each round is the whole **frontier** — every question whose prerequisites you have already settled — so you are never asked something that hinges on an answer it hasn't heard yet.
+`grill-me` takes a **loose idea** and interviews you until it has real decisions in it. You do not need a worked-out plan to start — producing one is what the session is for. It asks in **rounds**: each round is the whole **frontier** — every question whose prerequisites you have already settled — so you are never asked something that hinges on an answer it hasn't heard yet.
 
-It is **stateless**. It writes no files and leaves no workspace behind. The only thing it produces is a sharper plan in your own head.
+It is **stateless**. It writes no files and leaves no workspace behind. The only thing it leaves is a sharper version of the idea, in your own head.
 
 ## When to reach for it
 
 You invoke this by typing `/grill-me` — the agent won't reach for it on its own. Start it in a **fresh conversation**, not on top of a plan you already had an agent write.
 
-Reach for it when a plan feels roughly right and you suspect it isn't. Which of the three grilling skills you want depends on what is in front of you:
+Reach for it as soon as you have an idea worth taking seriously — a feature, a product direction, a business call, a piece of writing — and long before you have worked out what it involves. Vagueness is not a reason to wait; it is the thing the session eats. If you can already specify the thing precisely, you don't need to grill it.
 
-- **No codebase yet** — `grill-me`. There is nothing to align against, so there is nothing worth recording.
-- **A codebase** — [grill-with-docs](https://aihero.dev/skills-grill-with-docs). The same interview, but stateful: it keeps what it learns in `CONTEXT.md` and ADRs.
+Which of the three grilling skills you want depends on what is in front of you:
+
+- **Anything, anywhere** — `grill-me`. It needs no repo and writes no files, and the subject doesn't have to be code.
+- **A codebase to align against** — [grill-with-docs](https://aihero.dev/skills-grill-with-docs). The same interview, but stateful: it reads your code and keeps what it learns in `CONTEXT.md` and ADRs.
 - **Too big for one session** — [wayfinder](https://aihero.dev/skills-wayfinder). It charts the effort as a map and runs grilling sessions inside it.
 
 Leave plan mode off. Plan mode primes the agent to rush toward producing a plan, which is the opposite of staying in inquiry.
 
 ## It's a conversation, not an interview
 
-The skill asks the questions, but **you** own the scope. That is the part people miss, and it separates a session that sharpens a plan from one that produces confident nonsense.
+The skill asks the questions, but **you** own the scope. That is the part people miss, and it separates a session that turns an idea into decisions from one that produces confident nonsense.
 
 The failure mode is **passivity** — answering "agreed, agreed, agreed" for forty questions and coming out with a plan the agent wrote and you nodded at. It feels productive because it was long. Nothing was actually decided, and the result carries a certainty it hasn't earned.
 
@@ -69,4 +71,8 @@ More than for most skills. Grilling leans on the model's own sense of how system
 
 ## Where it fits
 
-`grill-me` is a reach-for-it-anytime standalone — the pre-build stress test you run whenever a plan needs hardening. It is the stateless, user-invoked front door to the [grilling](https://aihero.dev/skills-grilling) primitive; its closest neighbour is [grill-with-docs](https://aihero.dev/skills-grill-with-docs), the stateful sibling that runs the same interview against a codebase and records the decisions as ADRs and a glossary. When the plan is settled, hand the conversation to [to-spec](https://aihero.dev/skills-to-spec), which writes it up without re-interviewing you. When you're unsure which flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.
+`grill-me` is a **standalone you can run anywhere, on anything**. Being stateless is what makes it portable: no repo, no workspace, no setup, and no assumption that the idea is even about software. People point it at business decisions, at writing, at what to do next — anything that won't sit still in their head.
+
+That portability is the whole difference from [grill-with-docs](https://aihero.dev/skills-grill-with-docs), which runs the same interview but reads a codebase to align against and records what it learns as `CONTEXT.md` and ADRs. Both sit on the [grilling](https://aihero.dev/skills-grilling) primitive; `grill-me` is the user-invoked front door that carries nothing with it.
+
+If what you grilled does turn out to be software, you can hand the same conversation to [to-spec](https://aihero.dev/skills-to-spec) and carry on into the build flow — an option, not the point of the skill. When you're unsure which flow fits, [ask-matt](https://aihero.dev/skills-ask-matt) routes you.


### PR DESCRIPTION
**Stacked on #754** — merge that first, then this retargets to `main` automatically.

## Why

`grill-me` is the highest-traffic skill page and the one people are most confused by. The old page explained the mechanism — rounds, the frontier, the decision tree — and stopped there. It answered none of the questions people actually ask.

I mined the wiki (X, Discord, YouTube, GitHub) for what real users get wrong. The recurring themes, in order of volume:

1. **"Is grill-me obsolete now grill-with-docs / wayfinder exists?"** — asked repeatedly, never answered publicly.
2. **"How many questions is normal? When does it end?"** — people reported giving up at 48, and one session hit 501. Nobody knew the shape of a session.
3. **Passivity** — "I'm literally just saying agreed agreed agreed." One team lead: "It tricks people into thinking their stuff is well thought out."
4. **Questions that talking cannot answer** — users stuck on "Cytoscape or D3?" where the point was to *discover* the answer.
5. **Clearing context before `to-spec`** — throwing away the whole value of the session.

## What changed

- **Sibling routing** is a three-way list keyed on what you have in front of you (no codebase / a codebase / too big for one session), replacing a dense paragraph.
- **"It's a conversation, not an interview"** — new section naming passivity as the main failure mode.
- **"Grillable and ungrillable"** — new section giving the move for a question talking can't settle: stop, prototype, come back.
- **"Common questions"** — new section answering the six highest-volume questions, including how to restore one-question-at-a-time.
- **"It's working if"** — added, led by "you disagreed with something".
- Says plainly to leave plan mode off, and to start in a fresh conversation.

## Checks

- 865 words. Longer than any current page — this is the flagship page and the FAQ is the point, but say the word and I'll trim.
- No relative links. All 7 links return 200.
- No Quickstart block (per #754).

Part of [T2 · Walk the rendered docs site and set the page standards](https://github.com/mattpocock/personal-wiki/issues/251).

🤖 Generated with [Claude Code](https://claude.com/claude-code)