### PR TITLE
fix: make writing-for-agents model-invokable in Codex

### DIFF
--- a/.changeset/writing-for-agents-codex-metadata.md
+++ b/.changeset/writing-for-agents-codex-metadata.md
@@ -1,0 +1,9 @@
+---
+"mattpocock-skills": patch
+---
+
+Make `writing-for-agents` model-invokable in Codex again.
+
+- Drop `policy.allow_implicit_invocation: false` from `agents/openai.yaml`. Codex filtered the skill out of the model-visible skills list, so its description could not trigger it — only an explicit `$writing-for-agents` mention worked.
+- Update the stale `interface.display_name` and `interface.short_description`, which still named the old `writing-great-skills` skill.
+- Move the skill from the **User-invoked** list to the **Model-invoked** list in `README.md` and `skills/productivity/README.md`.

--- a/README.md
+++ b/README.md
@@ -224,8 +224,8 @@ General workflow tools, not code-specific.
 - **[teach](./skills/productivity/teach/SKILL.md)** — Teach the user a new skill or concept over multiple sessions, using the current directory as a stateful teaching workspace.
 - **[to-questionnaire](./skills/productivity/to-questionnaire/SKILL.md)** — Turn a decision you can't answer alone into a Markdown questionnaire for the one person who can — filled in async, or together over a meeting. It grills you about the send (who it's for, what you need back), not the subject.
 - **[wait-what](./skills/productivity/wait-what/SKILL.md)** — Fire this the moment a message doesn't land. The agent re-pitches it with the context you're missing, in plain English, using your `CONTEXT.md` vocabulary.
-- **[writing-for-agents](./skills/productivity/writing-for-agents/SKILL.md)** — Writing documents for agents: skills, AGENTS.md/CLAUDE.md, and any doc an agent reaches by a pointer.
 
 **Model-invoked**
 
 - **[grilling](./skills/productivity/grilling/SKILL.md)** — Interview the user relentlessly about a plan, decision, or idea until every branch of the design tree is resolved. The reusable interview primitive behind `grill-me`, `grill-with-docs`, `triage`, `wayfinder` and `improve-codebase-architecture`.
+- **[writing-for-agents](./skills/productivity/writing-for-agents/SKILL.md)** — Writing documents for agents: skills, AGENTS.md/CLAUDE.md, and any doc an agent reaches by a pointer.

--- a/skills/productivity/README.md
+++ b/skills/productivity/README.md
@@ -11,10 +11,10 @@ Reachable only when you type them (Claude Code: `disable-model-invocation: true`
 - **[teach](./teach/SKILL.md)** — Teach the user a new skill or concept over multiple sessions, using the current directory as a stateful teaching workspace.
 - **[to-questionnaire](./to-questionnaire/SKILL.md)** — Turn a decision you can't answer alone into a Markdown questionnaire for the one person who can — filled in async, or together over a meeting.
 - **[wait-what](./wait-what/SKILL.md)** — Fire this the moment a message doesn't land. The agent re-pitches it with the context you're missing, in plain English, using your `CONTEXT.md` vocabulary.
-- **[writing-for-agents](./writing-for-agents/SKILL.md)** — Writing documents for agents: skills, AGENTS.md/CLAUDE.md, and any doc an agent reaches by a pointer.
 
 ## Model-invoked
 
 Model- or user-reachable (rich trigger phrasing so the model can reach for them).
 
 - **[grilling](./grilling/SKILL.md)** — Interview the user relentlessly about a plan, decision, or idea until every branch of the design tree is resolved.
+- **[writing-for-agents](./writing-for-agents/SKILL.md)** — Writing documents for agents: skills, AGENTS.md/CLAUDE.md, and any doc an agent reaches by a pointer.

--- a/skills/productivity/writing-for-agents/agents/openai.yaml
+++ b/skills/productivity/writing-for-agents/agents/openai.yaml
@@ -1,5 +1,3 @@
 interface:
-  display_name: "Writing Great Skills"
-  short_description: "Principles for predictable skills"
-policy:
-  allow_implicit_invocation: false
+  display_name: "Writing for Agents"
+  short_description: "Write documents agents consume"


### PR DESCRIPTION
Closes #748.

The `writing-great-skills` → `writing-for-agents` rename moved `agents/openai.yaml` without updating its contents. Codex drops a skill from the model-visible skills list when `policy.allow_implicit_invocation` is `false`, so the skill's `description` could never trigger it — only a literal `$writing-for-agents` mention worked.

- Remove the `policy` block. Implicit invocation defaults to `true`, which matches the `SKILL.md` frontmatter (no `disable-model-invocation`).
- Correct `interface.display_name` ("Writing for Agents") and `interface.short_description`, both of which still named the old skill.
- Move the entry from **User-invoked** to **Model-invoked** in `README.md` and `skills/productivity/README.md`.

Reported and diagnosed by @myxvisual; @arphox proposed the display-name half of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)