### PR TITLE
fix: make diagnosing-bugs redact secrets

### DIFF
--- a/.changeset/diagnosing-bugs-redact-secrets.md
+++ b/.changeset/diagnosing-bugs-redact-secrets.md
@@ -4,6 +4,6 @@
 
 Make `diagnosing-bugs` redact secrets.
 
-- Add a **Redact** section to `SKILL.md`. The skill has the agent show commands, outputs and captured artifacts; the section makes redaction the first move on each — write `<REDACTED>`, show a command's shape (`Bearer $API_TOKEN`) rather than its credential, build loops against env vars, and redact HAR files, log dumps and payloads before quoting them.
+- Add a **Redact** section to `SKILL.md`. The skill has the agent show commands, outputs and captured artifacts; the section makes redaction the first move on each — write `<REDACTED>`, build loops against env vars so the credential stays in the environment, and quote only the signal-carrying lines of a captured artifact.
 - The Phase 1 completion criterion said "paste the invocation and its output". It now says show it redacted, and Phase 1 asks the user for a **redacted** captured artifact.
 - Note in `scripts/hitl-loop.template.sh` that `capture` prints its value back to the terminal, so it takes observations while signing in stays a `step`.

--- a/.changeset/diagnosing-bugs-redact-secrets.md
+++ b/.changeset/diagnosing-bugs-redact-secrets.md
@@ -1,0 +1,9 @@
+---
+"mattpocock-skills": patch
+---
+
+Make `diagnosing-bugs` redact secrets.
+
+- Add a **Redact** section to `SKILL.md`. The skill has the agent show commands, outputs and captured artifacts; the section makes redaction the first move on each — write `<REDACTED>`, show a command's shape (`Bearer $API_TOKEN`) rather than its credential, build loops against env vars, and redact HAR files, log dumps and payloads before quoting them.
+- The Phase 1 completion criterion said "paste the invocation and its output". It now says show it redacted, and Phase 1 asks the user for a **redacted** captured artifact.
+- Note in `scripts/hitl-loop.template.sh` that `capture` prints its value back to the terminal, so it takes observations while signing in stays a `step`.

--- a/skills/engineering/diagnosing-bugs/SKILL.md
+++ b/skills/engineering/diagnosing-bugs/SKILL.md
@@ -11,11 +11,7 @@ When exploring the codebase, read `CONTEXT.md` (if it exists) to get a clear men
 
 ## Redact
 
-This skill has you show commands, outputs and captured artifacts. **Redact every secret first** — API keys, tokens, passwords, cookies, session IDs, connection strings, signed URLs. Write `<REDACTED>` in its place.
-
-- **Show a command's shape, not its credential**: `curl -H "Authorization: Bearer $API_TOKEN" …`. The env var reference is the redacted form, and it still runs.
-- **Build loops against env vars**, so the credential stays in the environment rather than in the file you write or the output you quote.
-- **Redact captured artifacts** — HAR files, log dumps and request payloads carry auth headers. Quote only the lines that carry the signal.
+This skill has you show commands, outputs and captured artifacts. **Redact every secret first** — write `<REDACTED>` in its place. Build loops against env vars, so the credential stays in the environment rather than in what you show. Captured artifacts carry auth headers: quote only the lines that carry the signal.
 
 If the redacted output is not enough to diagnose the bug, say so and ask the user.
 

--- a/skills/engineering/diagnosing-bugs/SKILL.md
+++ b/skills/engineering/diagnosing-bugs/SKILL.md
@@ -9,6 +9,16 @@ A discipline for hard bugs. Skip phases only when explicitly justified.
 
 When exploring the codebase, read `CONTEXT.md` (if it exists) to get a clear mental model of the relevant modules, and check ADRs in the area you're touching.
 
+## Redact
+
+This skill has you show commands, outputs and captured artifacts. **Redact every secret first** — API keys, tokens, passwords, cookies, session IDs, connection strings, signed URLs. Write `<REDACTED>` in its place.
+
+- **Show a command's shape, not its credential**: `curl -H "Authorization: Bearer $API_TOKEN" …`. The env var reference is the redacted form, and it still runs.
+- **Build loops against env vars**, so the credential stays in the environment rather than in the file you write or the output you quote.
+- **Redact captured artifacts** — HAR files, log dumps and request payloads carry auth headers. Quote only the lines that carry the signal.
+
+If the redacted output is not enough to diagnose the bug, say so and ask the user.
+
 ## Phase 1 — Build a feedback loop
 
 **This is the skill.** Everything else is mechanical. If you have a **tight** pass/fail signal for the bug — one that goes red on _this_ bug — you will find the cause; bisection, hypothesis-testing, and instrumentation all just consume it. If you don't have one, no amount of staring at code will save you.
@@ -46,11 +56,11 @@ The goal is not a clean repro but a **higher reproduction rate**. Loop the trigg
 
 ### When you genuinely cannot build a loop
 
-Stop and say so explicitly. List what you tried. Ask the user for: (a) access to whatever environment reproduces it, (b) a captured artifact (HAR file, log dump, core dump, screen recording with timestamps), or (c) permission to add temporary production instrumentation. Do **not** proceed to hypothesise without a loop.
+Stop and say so explicitly. List what you tried. Ask the user for: (a) access to whatever environment reproduces it, (b) a redacted captured artifact (HAR file, log dump, core dump, screen recording with timestamps), or (c) permission to add temporary production instrumentation. Do **not** proceed to hypothesise without a loop.
 
 ### Completion criterion — a tight loop that goes red
 
-Phase 1 is done when the loop is **tight** and **red-capable**: you can name **one command** — a script path, a test invocation, a curl — that you have **already run at least once** (paste the invocation and its output), and that is:
+Phase 1 is done when the loop is **tight** and **red-capable**: you can name **one command** — a script path, a test invocation, a curl — that you have **already run at least once** (show the invocation and its output, redacted), and that is:
 
 - [ ] **Red-capable** — it drives the actual bug code path and asserts the **user's exact symptom**, so it can go red on this bug and green once fixed. Not "runs without erroring" — it must be able to _catch this specific bug_.
 - [ ] **Deterministic** — same verdict every run (flaky bugs: a pinned, high reproduction rate, per above).

--- a/skills/engineering/diagnosing-bugs/scripts/hitl-loop.template.sh
+++ b/skills/engineering/diagnosing-bugs/scripts/hitl-loop.template.sh
@@ -11,6 +11,9 @@
 #   capture VAR "<question>"      → show question, read response into VAR
 #
 # At the end, captured values are printed as KEY=VALUE for the agent to parse.
+#
+# `capture` prints its value back to the terminal, where the agent reads it — so
+# capture observations, and leave signing in to the user as a `step`.
 
 set -euo pipefail
 


### PR DESCRIPTION
Closes a Snyk finding on the `diagnosing-bugs` skill — **W007, HIGH (confidence 0.80)**, insecure credential handling, reported on the [skills.sh audit page](https://www.skills.sh/mattpocock/skills/diagnosing-bugs/security/snyk).

## The finding

The skill has three paths by which a live credential can end up reproduced in the agent's response:

1. The Phase 1 completion criterion said **"paste the invocation and its output"** — for a curl loop, that is an `Authorization` header.
2. When no loop is possible, Phase 1 asks the user for a **captured artifact** (HAR file, log dump), which carries auth headers.
3. `scripts/hitl-loop.template.sh` prints every `capture` value back to the terminal, where the agent reads it.

## The fix

- **New `## Redact` section**, three sentences — redaction is the first move on every command, output and artifact the skill has the agent show: write `<REDACTED>`, build loops against env vars so the credential stays in the environment, and quote only the signal-carrying lines of an artifact.
- **Both call sites point at it** in one word rather than restating the rule — the completion criterion now says show the invocation and its output *redacted*, and Phase 1 asks for a *redacted* captured artifact.
- **HITL template** notes that `capture` takes observations, while signing in stays a `step`.

One line is deliberate rather than incidental: *"If the redacted output is not enough to diagnose the bug, say so and ask the user."* The skill's own pressure to produce a red loop is exactly what would push an agent to paste the raw value, so the escape hatch needs writing.

## Notes

Written against `writing-for-agents`: `redact` is the leading word, repeated as a token at all three sites; the rule is stated positively throughout (`build loops against env vars`, not `never read .env`), since steering by prohibition makes the forbidden act more available, not less. No exemplars — the model does not need telling what a secret looks like.

`bash -n` passes on the template. Changeset included (patch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)