### PR TITLE
fix: make subagent dispatch harness-neutral

### DIFF
--- a/.changeset/harness-neutral-subagent-language.md
+++ b/.changeset/harness-neutral-subagent-language.md
@@ -1,0 +1,7 @@
+---
+"mattpocock-skills": patch
+---
+
+Make the subagent-dispatch instructions harness-neutral.
+
+`code-review`, `codebase-design`'s `DESIGN-IT-TWICE.md`, and `improve-codebase-architecture` named Claude Code's `Agent` tool and its `general-purpose` / `Explore` agent types directly. Codex and other Agent-Skills harnesses have no such tool or type, so the instruction was unfollowable there. Each now describes the *shape* of the dispatch — parallel subagents, and what capability each one needs — and leaves the mechanism to the harness.

--- a/.changeset/harness-neutral-subagent-language.md
+++ b/.changeset/harness-neutral-subagent-language.md
@@ -2,6 +2,4 @@
 "mattpocock-skills": patch
 ---
 
-Make the subagent-dispatch instructions harness-neutral.
-
-`code-review`, `codebase-design`'s `DESIGN-IT-TWICE.md`, and `improve-codebase-architecture` named Claude Code's `Agent` tool and its `general-purpose` / `Explore` agent types directly. Codex and other Agent-Skills harnesses have no such tool or type, so the instruction was unfollowable there. Each now describes the *shape* of the dispatch — parallel subagents, and what capability each one needs — and leaves the mechanism to the harness.
+Drop Claude Code's tool and agent-type names from the subagent-dispatch instructions in `code-review`, `codebase-design`, and `improve-codebase-architecture`, so the step is followable on Codex and other harnesses.

--- a/skills/engineering/code-review/SKILL.md
+++ b/skills/engineering/code-review/SKILL.md
@@ -57,8 +57,6 @@ Each smell reads *what it is* → *how to fix*; match it against the diff:
 
 ### 4. Spawn both sub-agents in parallel
 
-Dispatch both with your harness's subagent mechanism, in parallel — one message with two calls where the harness supports it. Pick its most general-purpose agent for both: each must read files and run `git`, so a search-only agent is too narrow.
-
 **Standards sub-agent prompt** — include:
 
 - The full diff command and commit list.

--- a/skills/engineering/code-review/SKILL.md
+++ b/skills/engineering/code-review/SKILL.md
@@ -57,7 +57,7 @@ Each smell reads *what it is* → *how to fix*; match it against the diff:
 
 ### 4. Spawn both sub-agents in parallel
 
-Send a single message with two `Agent` tool calls. Use the `general-purpose` subagent for both.
+Dispatch both with your harness's subagent mechanism, in parallel — one message with two calls where the harness supports it. Pick its most general-purpose agent for both: each must read files and run `git`, so a search-only agent is too narrow.
 
 **Standards sub-agent prompt** — include:
 

--- a/skills/engineering/codebase-design/DESIGN-IT-TWICE.md
+++ b/skills/engineering/codebase-design/DESIGN-IT-TWICE.md
@@ -18,7 +18,7 @@ Show this to the user, then immediately proceed to Step 2. The user reads and th
 
 ### 2. Spawn sub-agents
 
-Spawn 3+ sub-agents in parallel with your harness's subagent mechanism. Each must produce a **radically different** interface for the deepened module.
+Spawn 3+ sub-agents in parallel. Each must produce a **radically different** interface for the deepened module.
 
 Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
 

--- a/skills/engineering/codebase-design/DESIGN-IT-TWICE.md
+++ b/skills/engineering/codebase-design/DESIGN-IT-TWICE.md
@@ -18,7 +18,7 @@ Show this to the user, then immediately proceed to Step 2. The user reads and th
 
 ### 2. Spawn sub-agents
 
-Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+Spawn 3+ sub-agents in parallel with your harness's subagent mechanism. Each must produce a **radically different** interface for the deepened module.
 
 Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category from [DEEPENING.md](DEEPENING.md), what sits behind the seam). The brief is independent of the user-facing problem-space explanation in Step 1. Give each agent a different design constraint:
 

--- a/skills/engineering/improve-codebase-architecture/SKILL.md
+++ b/skills/engineering/improve-codebase-architecture/SKILL.md
@@ -24,7 +24,7 @@ This command is _informed_ by the project's domain model and built on a shared d
 
 Read the project's domain glossary (`CONTEXT.md`) and any ADRs in the area you're touching first.
 
-Then use the Agent tool with `subagent_type=Explore` to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
+Then dispatch a subagent to walk the codebase — a read-only exploration agent if your harness has one. Don't follow rigid heuristics — explore organically and note where you experience friction:
 
 - Where does understanding one concept require bouncing between many small modules?
 - Where are modules **shallow** — interface nearly as complex as the implementation?

--- a/skills/engineering/improve-codebase-architecture/SKILL.md
+++ b/skills/engineering/improve-codebase-architecture/SKILL.md
@@ -24,7 +24,7 @@ This command is _informed_ by the project's domain model and built on a shared d
 
 Read the project's domain glossary (`CONTEXT.md`) and any ADRs in the area you're touching first.
 
-Then dispatch a subagent to walk the codebase — a read-only exploration agent if your harness has one. Don't follow rigid heuristics — explore organically and note where you experience friction:
+Then spawn a sub-agent to walk the codebase. Don't follow rigid heuristics — explore organically and note where you experience friction:
 
 - Where does understanding one concept require bouncing between many small modules?
 - Where are modules **shallow** — interface nearly as complex as the implementation?


### PR DESCRIPTION
Three skills named Claude Code's `Agent` tool and its `general-purpose` / `Explore` agent types when telling the agent to spawn sub-agents. Those names exist only in Claude Code, and this repo installs across Codex and other Agent-Skills harnesses ([ADR 0002](https://github.com/mattpocock/skills/blob/main/.agents/adr/0002-ship-as-a-claude-code-plugin.md)) — so the step named a tool that isn't there.

| File | Was | Now |
|---|---|---|
| `code-review/SKILL.md` | "Send a single message with two \`Agent\` tool calls. Use the \`general-purpose\` subagent for both." | *(deleted — the heading above it already says "Spawn both sub-agents in parallel")* |
| `codebase-design/DESIGN-IT-TWICE.md` | "Spawn 3+ sub-agents in parallel using the Agent tool." | "Spawn 3+ sub-agents in parallel." |
| `improve-codebase-architecture/SKILL.md` | "use the Agent tool with \`subagent_type=Explore\`" | "spawn a sub-agent" |

Net -3 lines. Naming the mechanism was the only harness-bound part; the shape of the dispatch carries the behaviour on its own.

## What I did not change

I swept `skills/` for the other half of the question — `CLAUDE.md` assumptions — and found none worth fixing. `setup-matt-pocock-skills` and `setup-ts-deep-modules` both pick `CLAUDE.md` **or** `AGENTS.md` by which exists; `writing-for-agents` names both by design; `claude-handoff` and `git-guardrails-claude-code` are Claude-specific on purpose; the bucket READMEs name Claude Code and Codex side by side when explaining invocation.

`ask-matt` / `PHASE-BOUNDARIES.md` use `/clear` and `/compact` as context-management vocabulary rather than harness API — left alone.

## Notes

Wording-only, so no docs page re-sync and no `ask-matt` update. Changeset added as a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)