### PR TITLE
docs(grill-me): drop the "holds decisions" phrasing

### DIFF
--- a/docs/productivity/grill-me.md
+++ b/docs/productivity/grill-me.md
@@ -1,6 +1,6 @@
 ## What it does
 
-`grill-me` takes a **loose idea** and interviews you until it has real decisions in it. You do not need a worked-out plan to start — producing one is what the [session](https://www.aihero.dev/ai-coding-dictionary/session) is for. It asks in **rounds**: each round is the whole **frontier** — every question whose prerequisites you have already settled — so you are never asked something that hinges on an answer it hasn't heard yet.
+`grill-me` takes a **loose idea** and interviews you until you can commit to it. You do not need a worked-out plan to start — producing one is what the [session](https://www.aihero.dev/ai-coding-dictionary/session) is for. It asks in **rounds**: each round is the whole **frontier** — every question whose prerequisites you have already settled — so you are never asked something that hinges on an answer it hasn't heard yet.
 
 It is **[stateless](https://www.aihero.dev/ai-coding-dictionary/stateless)**. It writes no files and leaves no workspace behind. The only thing it leaves is a sharper version of the idea, in your own head.
 


### PR DESCRIPTION
The `/grill-me` row on `aihero.dev/skills` read "Get interviewed about a loose idea until it holds decisions." That phrase is now "Align on an idea before committing to it." (CMS-owned, already live).

The docs page opened with the same metaphor — "interviews you until it has real decisions in it" — so this aligns it: "interviews you until you can commit to it."

One line. The page body is leased to this file, so the live page updates on the next sync after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)