### PR TITLE
domain-modeling: trigger on CONTEXT.md / ADR writes

### DIFF
--- a/.changeset/domain-modeling-trigger-context-adr.md
+++ b/.changeset/domain-modeling-trigger-context-adr.md
@@ -2,4 +2,4 @@
 "mattpocock-skills": patch
 ---
 
-domain-modeling: trigger on discussing codebase terminology and on writing or editing a CONTEXT.md or an ADR directly, replacing the narrower "pin down domain terminology or a ubiquitous language" / "record an architectural decision" phrasing.
+domain-modeling: trigger on discussing codebase terminology and on writing or editing a CONTEXT.md or an ADR directly, replacing the narrower "pin down domain terminology or a ubiquitous language" / "record an architectural decision" phrasing. Also drops the "another skill needs to maintain the domain model" caveat — that's the invoking skill's job to state explicitly, not this description's.

--- a/.changeset/domain-modeling-trigger-context-adr.md
+++ b/.changeset/domain-modeling-trigger-context-adr.md
@@ -1,0 +1,5 @@
+---
+"mattpocock-skills": patch
+---
+
+domain-modeling: trigger on writing or editing a CONTEXT.md or an ADR directly, not just when the request is framed as "pin down terminology" or "record a decision".

--- a/.changeset/domain-modeling-trigger-context-adr.md
+++ b/.changeset/domain-modeling-trigger-context-adr.md
@@ -2,4 +2,4 @@
 "mattpocock-skills": patch
 ---
 
-domain-modeling: trigger on writing or editing a CONTEXT.md or an ADR directly, not just when the request is framed as "pin down terminology" or "record a decision".
+domain-modeling: trigger on discussing codebase terminology and on writing or editing a CONTEXT.md or an ADR directly, replacing the narrower "pin down domain terminology or a ubiquitous language" / "record an architectural decision" phrasing.

--- a/skills/engineering/domain-modeling/SKILL.md
+++ b/skills/engineering/domain-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain-modeling
-description: Build and sharpen a project's domain model. Use when discussing codebase terminology, writing or editing a CONTEXT.md, recording or editing an ADR, or when another skill needs to maintain the domain model.
+description: Build and sharpen a project's domain model. Use when discussing codebase terminology, writing or editing a CONTEXT.md, or recording or editing an ADR.
 ---
 
 # Domain Modeling

--- a/skills/engineering/domain-modeling/SKILL.md
+++ b/skills/engineering/domain-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain-modeling
-description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, write or edit a CONTEXT.md, record or edit an ADR, or when another skill needs to maintain the domain model.
+description: Build and sharpen a project's domain model. Use when discussing codebase terminology, writing or editing a CONTEXT.md, recording or editing an ADR, or when another skill needs to maintain the domain model.
 ---
 
 # Domain Modeling

--- a/skills/engineering/domain-modeling/SKILL.md
+++ b/skills/engineering/domain-modeling/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: domain-modeling
-description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, record an architectural decision, or when another skill needs to maintain the domain model.
+description: Build and sharpen a project's domain model. Use when the user wants to pin down domain terminology or a ubiquitous language, write or edit a CONTEXT.md, record or edit an ADR, or when another skill needs to maintain the domain model.
 ---
 
 # Domain Modeling


### PR DESCRIPTION
## Summary
- The `domain-modeling` skill description only fired on conversational framing ("pin down terminology", "record a decision"), so it could be skipped when the actual request was just "write a CONTEXT.md" or "edit this ADR".
- Adds explicit triggers for writing/editing a `CONTEXT.md` and recording/editing an ADR to the frontmatter `description`, so the skill loads reliably whenever those files are touched, not just when the underlying activity is phrased conversationally.

## Test plan
- [ ] Confirm the skill fires when asked to "write a CONTEXT.md" with no other framing
- [ ] Confirm the skill fires when asked to "edit this ADR" with no other framing
- [ ] `claude plugin validate . --strict` (frontmatter-only change, no manifest touched)