### PR TITLE
wait-what: follow CONTEXT-MAP.md to the right CONTEXT.md

### DIFF
--- a/.changeset/wait-what-context-map.md
+++ b/.changeset/wait-what-context-map.md
@@ -1,0 +1,5 @@
+---
+"mattpocock-skills": patch
+---
+
+wait-what: follow `CONTEXT-MAP.md` to the right `CONTEXT.md` when a repo indexes multiple contexts that way instead of keeping a single root `CONTEXT.md`.

--- a/docs/productivity/wait-what.md
+++ b/docs/productivity/wait-what.md
@@ -22,7 +22,7 @@ The skill says re-pitch **that**, not "that last message". What lost you is usua
 
 The body reuses the leading words already in your global `CLAUDE.md` and your project's `CONTEXT.md`. ASD-STE100 Simplified Technical English sets the register. The ubiquitous language supplies the nouns. The skill, `CLAUDE.md` and `CONTEXT.md` reach for the same [tokens](https://www.aihero.dev/ai-coding-dictionary/token), so invoking it is not a new instruction. It is a reminder of one the agent already agreed to.
 
-If you have no `CONTEXT.md`, the skill still works. You lose only the domain-vocabulary half.
+If you have no `CONTEXT.md` — and no `CONTEXT-MAP.md` pointing to one for the context at hand — the skill still works. You lose only the domain-vocabulary half.
 
 ## It's working if
 

--- a/skills/productivity/wait-what/SKILL.md
+++ b/skills/productivity/wait-what/SKILL.md
@@ -4,4 +4,4 @@ description: Stop. That last message did not land — re-pitch it.
 disable-model-invocation: true
 ---
 
-Wait — I don't understand where you've got to here. Re-pitch that: give me a little bit of context, talk in ASD-STE100 Simplified Technical English, and use the ubiquitous language from `CONTEXT.md`.
+Wait — I don't understand where you've got to here. Re-pitch that: give me a little bit of context, talk in ASD-STE100 Simplified Technical English, and use the ubiquitous language from `CONTEXT.md` (follow `CONTEXT-MAP.md` to the right one if the repo has more than one).


### PR DESCRIPTION
## Summary

- `wait-what` re-pitches a message using the ubiquitous language from `CONTEXT.md`, but had no notion of `CONTEXT-MAP.md` — the multi-context index some repos use instead of a single root `CONTEXT.md`. On a repo like that, the skill fell silent on vocabulary instead of following the map.
- Adds one clause to the skill body pointing it at `CONTEXT-MAP.md` when the repo has more than one context, and a matching one-line correction to the docs page so it doesn't claim vocabulary is unavailable in that case.

Kept deliberately tiny — the skill is three lines by design (see its docs: "Skills that fight verbosity fail by growing").

## Test plan

- [ ] Re-run `wait-what` in a multi-context repo (one with `CONTEXT-MAP.md` and no root `CONTEXT.md`) and confirm it follows the map to the relevant `CONTEXT.md` instead of falling back to code-level vocabulary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)