### PR TITLE
Fix invalid YAML front matter in six SKILL.md files

### DIFF
--- a/.changeset/fix-yaml-frontmatter-colons.md
+++ b/.changeset/fix-yaml-frontmatter-colons.md
@@ -1,0 +1,5 @@
+---
+"mattpocock-skills": patch
+---
+
+Quote the `description` front matter in `to-spec`, `code-review`, `setup-matt-pocock-skills`, `writing-fragments`, `writing-shape`, and `wait-what`. An unquoted colon-space left over from the em-dash sweep in #905 made each block invalid YAML, so `skills.sh` skipped all six during discovery and they couldn't be listed or installed via `npx skills`.

--- a/skills/engineering/code-review/SKILL.md
+++ b/skills/engineering/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Review the changes since a fixed point (commit, branch, tag, or merge-base) along two axes: Standards (does the code follow this repo's documented coding standards?) and Spec (does the code match what the originating issue/spec asked for?). Runs both reviews in parallel sub-agents and reports them side by side. Use when the user wants to review a branch, a PR, work-in-progress changes, or asks to "review since X".
+description: "Review the changes since a fixed point (commit, branch, tag, or merge-base) along two axes: Standards (does the code follow this repo's documented coding standards?) and Spec (does the code match what the originating issue/spec asked for?). Runs both reviews in parallel sub-agents and reports them side by side. Use when the user wants to review a branch, a PR, work-in-progress changes, or asks to \"review since X\"."
 ---
 
 Two-axis review of the diff between `HEAD` and a fixed point the user supplies:

--- a/skills/engineering/setup-matt-pocock-skills/SKILL.md
+++ b/skills/engineering/setup-matt-pocock-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: setup-matt-pocock-skills
-description: Configure this repo for the engineering skills: set up its issue tracker, triage label vocabulary, and domain doc layout. Run once before first use of the other engineering skills.
+description: "Configure this repo for the engineering skills: set up its issue tracker, triage label vocabulary, and domain doc layout. Run once before first use of the other engineering skills."
 disable-model-invocation: true
 ---
 

--- a/skills/engineering/to-spec/SKILL.md
+++ b/skills/engineering/to-spec/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: to-spec
-description: Turn the current conversation into a spec and publish it to the project issue tracker: no interview, just synthesis of what you've already discussed.
+description: "Turn the current conversation into a spec and publish it to the project issue tracker: no interview, just synthesis of what you've already discussed."
 disable-model-invocation: true
 ---
 

--- a/skills/in-progress/writing-fragments/SKILL.md
+++ b/skills/in-progress/writing-fragments/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-fragments
-description: Writing, explore: mine raw fragments, no structure yet.
+description: "Writing, explore: mine raw fragments, no structure yet."
 disable-model-invocation: true
 ---
 

--- a/skills/in-progress/writing-shape/SKILL.md
+++ b/skills/in-progress/writing-shape/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-shape
-description: Writing, exploit: shape raw material into an article, paragraph by paragraph.
+description: "Writing, exploit: shape raw material into an article, paragraph by paragraph."
 disable-model-invocation: true
 ---
 

--- a/skills/productivity/wait-what/SKILL.md
+++ b/skills/productivity/wait-what/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wait-what
-description: Stop. That last message did not land: re-pitch it.
+description: "Stop. That last message did not land: re-pitch it."
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Summary
- Quotes the `description` front-matter scalar in six `SKILL.md` files where an unquoted colon-space sequence made the YAML invalid, causing `skills.sh` to skip them during discovery (they couldn't be listed or installed via `npx skills`)
- The invalid colons were introduced by #905's em-dash-to-colon sweep, which validated YAML files generally but didn't run every `SKILL.md` front-matter block through the parser `skills.sh` uses
- Files fixed: `skills/engineering/to-spec/SKILL.md`, `skills/engineering/code-review/SKILL.md`, `skills/engineering/setup-matt-pocock-skills/SKILL.md`, `skills/in-progress/writing-fragments/SKILL.md`, `skills/in-progress/writing-shape/SKILL.md`, `skills/productivity/wait-what/SKILL.md`
- Wording is unchanged — only quoting was added, matching the existing style used by e.g. `skills/engineering/implement/SKILL.md`

Fixes #907

## Test plan
- [x] Parsed the front matter of all 35 `SKILL.md` files in the repo with PyYAML's `safe_load` (the same style of parser `skills.sh` uses) — all 35 now parse cleanly, down from 6 failures before the fix
- [ ] `npx skills add mattpocock/skills --global --agent claude-code --skill to-spec --yes` picks up `to-spec` (and the other five) during discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)