### PR TITLE
grilling: separate questions in a round with an HR

### DIFF
--- a/.changeset/grilling-add-hr-between-questions.md
+++ b/.changeset/grilling-add-hr-between-questions.md
@@ -1,0 +1,5 @@
+---
+"mattpocock-skills": patch
+---
+
+grilling: update the round template so consecutive questions are separated by a horizontal rule (`---`) instead of running together.

--- a/skills/productivity/grilling/SKILL.md
+++ b/skills/productivity/grilling/SKILL.md
@@ -7,10 +7,16 @@ Interview the user relentlessly until you reach a shared understanding. Map this
 
 Work the tree in **rounds**. The **frontier** is every decision whose prerequisites are already settled: the questions you can ask _now_ without guessing at answers you haven't heard yet. Ask the whole frontier in one round: number each question and give your recommended answer. Then wait for the user's answers before the next round.
 
-Each question should be formatted like so:
+Format a round like so:
 
 ```
 ❓ **Q1** - **<question title>**: <question body, might be multiple paragraphs, including multiple choices>
+
+➡️ <your recommended answer>
+
+---
+
+❓ **Q2** - **<question title>**: <question body, might be multiple paragraphs, including multiple choices>
 
 ➡️ <your recommended answer>
 ```


### PR DESCRIPTION
## Summary
- Multi-question rounds in the `grilling` skill had no visual separator, so consecutive `❓`/`➡️` blocks ran straight into each other.
- Adds one line to `SKILL.md` instructing the agent to insert a horizontal rule (`---`) between consecutive questions within the same round.
- Adds a changeset (patch bump) per this repo's convention.

## Test plan
- [ ] Skim `skills/productivity/grilling/SKILL.md` to confirm the new line reads naturally alongside the existing question-format block.
- [ ] Run `/grill` (or trigger the grilling skill) with a multi-question round and confirm the model inserts `---` between questions.