### PR TITLE
link-skills: stop linking misc/ into local skill directories

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,6 @@ Every `SKILL.md` is either user-invoked (`disable-model-invocation: true` plus `
 
 [`ask-matt`](./skills/engineering/ask-matt/SKILL.md) is the router that maps every user-reachable skill and how they relate. The same trigger that re-syncs a docs page applies to it: whenever you add, rename, remove, or change how a user-reachable skill fits the flows, re-read `ask-matt`'s `SKILL.md` and update it so the map stays accurate: a new skill it never mentions, or a stale one it still routes to, is a router that lies.
 
-To (re)link every skill into the local harness skill directories (`~/.claude/skills`, `~/.agents/skills`), run `scripts/link-skills.sh`. Each entry is a symlink into this repo, so a `git pull` keeps installed skills current; re-run the script after adding, removing, or renaming a skill.
+To (re)link every skill outside `deprecated/` and `misc/` into the local harness skill directories (`~/.claude/skills`, `~/.agents/skills`), run `scripts/link-skills.sh`. Each entry is a symlink into this repo, so a `git pull` keeps installed skills current; re-run the script after adding, removing, or renaming a skill.
 
 No em-dashes anywhere in this repo's prose (`SKILL.md` files, docs, `README.md`, `CHANGELOG.md`, ADRs, changesets, code comments). Where a sentence reaches for one, rewrite it instead with a comma, colon, period, parentheses, or a conjunction, whichever the sentence actually wants; never do a blind character substitution.

--- a/scripts/link-skills.sh
+++ b/scripts/link-skills.sh
@@ -15,14 +15,20 @@ set -euo pipefail
 REPO="$(cd "$(dirname "$0")/.." && pwd)"
 DESTS=("$HOME/.claude/skills" "$HOME/.agents/skills")
 
-# Collect the repo's skills once, link into every destination.
+# Collect the repo's skills once, link into every destination. `deprecated/`
+# is retired, and `misc/` is kept around but rarely used and not promoted (see
+# each bucket's own README): neither belongs in a daily-driver skill
+# directory, so both are skipped here, same as everywhere else non-promoted
+# skills are kept out. `in-progress/` IS still linked: it's public on purpose,
+# feedback wanted, and this local install is exactly where that feedback loop
+# runs.
 names=()
 srcs=()
 while IFS= read -r -d '' skill_md; do
   src="$(dirname "$skill_md")"
   names+=("$(basename "$src")")
   srcs+=("$src")
-done < <(find "$REPO/skills" -name SKILL.md -not -path '*/node_modules/*' -not -path '*/deprecated/*' -print0)
+done < <(find "$REPO/skills" -name SKILL.md -not -path '*/node_modules/*' -not -path '*/deprecated/*' -not -path '*/misc/*' -print0)
 
 for DEST in "${DESTS[@]}"; do
   # If $DEST is a symlink that resolves into this repo, we'd end up writing the


### PR DESCRIPTION
## Why

Follow-up to dropping `misc/*` from the personal-wiki repo's Discord slash-command picker (mattpocock/personal-wiki#470). Same question came up here: `misc/` skills (`git-guardrails-claude-code`, `migrate-to-shoehorn`, `scaffold-exercises`, `setup-pre-commit`) were being symlinked into `~/.claude/skills` and `~/.agents/skills` by `scripts/link-skills.sh`, which only ever excluded `deprecated/`.

`misc/README.md` already calls these out as "kept around but rarely used, not promoted in the plugin" — this just makes the local install match that.

## What changed

```
scripts/link-skills.sh
  find "$REPO/skills" -name SKILL.md
    -not -path '*/node_modules/*'
    -not -path '*/deprecated/*'
+   -not -path '*/misc/*'
```

`in-progress/` is untouched on purpose: per ADR 0002, it's public and feedback-seeking, and the local install is where that feedback loop actually runs. Only `misc/` (rarely-used, not promoted, but not retired either) moves into the same excluded bucket as `deprecated/`.

Also updated the one line in `CLAUDE.md` that described the script as linking "every skill", since that's now `deprecated/`- and `misc/`-excluded.

## Test plan

- [x] Ran `scripts/link-skills.sh` against a scratch `$HOME`: all four `misc/*` skills are absent from both `~/.claude/skills` and `~/.agents/skills`; every `engineering/`, `productivity/`, and `in-progress/` skill still links normally
- [x] `bash -n scripts/link-skills.sh` (syntax check)
- [x] No em-dashes introduced (repo-wide prose rule)